### PR TITLE
Clone the hashset before looping to prevent concurrent modification when...

### DIFF
--- a/src/main/java/org/commonjava/maven/ext/manip/impl/DependencyManipulator.java
+++ b/src/main/java/org/commonjava/maven/ext/manip/impl/DependencyManipulator.java
@@ -317,7 +317,7 @@ public class DependencyManipulator
         final boolean wildcardMode[] = { false, true };
         for ( int i = 0; i < wildcardMode.length; i++ )
         {
-            for ( final String currentKey : remainingOverrides.keySet() )
+            for ( final String currentKey : new HashSet<String>(remainingOverrides.keySet()))
             {
                 logger.debug( "Processing key for override: {}", currentKey );
 


### PR DESCRIPTION
... removing
