### PR TITLE
[issue-95] Handle existing bad osgi versions in the repo

### DIFF
--- a/src/main/java/org/commonjava/maven/ext/manip/impl/VersionCalculator.java
+++ b/src/main/java/org/commonjava/maven/ext/manip/impl/VersionCalculator.java
@@ -360,7 +360,9 @@ public class VersionCalculator
 
                 final String base = version.substring( 0, baseIdx - 1 );
                 logger.debug( "Candidate version base is: '{}'", base );
-                if ( !baseVersion.equals( base ) )
+                String trimmedBaseVersion = trimVersionZeros( baseVersion );
+                String trimmedBase = trimVersionZeros( base );
+                if ( !trimmedBaseVersion.equals( trimmedBase ) )
                 {
                     logger.debug( "Ignoring irrelevant version: '" + version + "' ('" + base
                         + "' doesn't match on base-version: '" + baseVersion + "')." );
@@ -381,6 +383,24 @@ public class VersionCalculator
             vc.setSuffixSeparator( sep );
             vc.setIncrementalQualifier( maxSerial + 1 );
         }
+    }
+
+    /**
+     * Remove irrelevant zeros from a version string.
+     * This is useful when trying to match two version strings where one has zeros
+     * in the minor and/or micro fields, for example 1.2.0 and 1.2.
+     * 
+     * @param version
+     * @return
+     */
+    public static String trimVersionZeros(String version) 
+    {
+        String newVersion = version ;
+        while ( newVersion.endsWith( ".0" ) )
+        {
+            newVersion = newVersion.substring( 0, newVersion.lastIndexOf( ".0" ) );
+        }
+        return newVersion.toString();
     }
 
     /**

--- a/src/test/java/org/commonjava/maven/ext/manip/impl/VersioningCalculatorTest.java
+++ b/src/test/java/org/commonjava/maven/ext/manip/impl/VersioningCalculatorTest.java
@@ -554,6 +554,22 @@ public class VersioningCalculatorTest
     }
 
     @Test
+    public void incrementExistingSerialSuffix_withOsgiVersionChangeExistingVersionsMicro()
+        throws Exception
+    {
+        final Properties props = new Properties();
+
+        props.setProperty( VersioningState.INCREMENT_SERIAL_SUFFIX_SYSPROP, "foo" );
+        setupSession( props, "1.2-foo-1", "1.2.foo-2" );
+
+        final String v = "1.2";
+        final String ns = "foo-3";
+
+        final String result = calculate( v );
+        assertThat( result, equalTo( v + ".0." + ns ) );
+    }
+
+    @Test
     public void incrementExistingSerialSuffix_TwoProjects_UsingRepositoryMetadata_AvailableOnlyForOne()
         throws Exception
     {


### PR DESCRIPTION
If there is a version in the repo already that looks like 1.2-redhat-1 or
1.2.redhat-1, the next osgi compat version increment should be 1.2.0.redhat-2
