### PR TITLE
NCLSUP1410 Handle properties in GAV 

### DIFF
--- a/cli/src/main/java/org/jboss/pnc/mavenmanipulator/cli/Cli.java
+++ b/cli/src/main/java/org/jboss/pnc/mavenmanipulator/cli/Cli.java
@@ -282,7 +282,7 @@ public class Cli implements Callable<Integer> {
                 List<ArtifactRef> ts = RESTCollector
                         .establishAllDependencies(
                                 session,
-                                pomIO.parseProject(session.getPom()),
+                                pomIO.parseProject(session, session.getPom()),
                                 profiles)
                         .stream()
                         .sorted()

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/model/Project.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/model/Project.java
@@ -209,6 +209,13 @@ public class Project {
         return new SimpleProjectVersionRef(getGroupId(), getArtifactId(), getVersion());
     }
 
+    public ProjectVersionRef getResolvedKey() {
+        return new SimpleProjectVersionRef(
+                PropertyResolver.resolvePropertiesUnchecked(session, getInheritedList(), getGroupId()),
+                PropertyResolver.resolvePropertiesUnchecked(session, getInheritedList(), getArtifactId()),
+                PropertyResolver.resolvePropertiesUnchecked(session, getInheritedList(), getVersion()));
+    }
+
     public Parent getModelParent() {
         return model.getParent();
     }

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/model/Project.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/model/Project.java
@@ -261,11 +261,10 @@ public class Project {
      * Model as it is the same object, if you wish to remove or add items to the Model then you
      * must use {@link #getModel()}
      *
-     * @param session MavenSessionHandler, used by {@link PropertyResolver}
      * @return a list of fully resolved {@link ArtifactRef} to the original {@link Dependency}
      * @throws ManipulationException if an error occurs
      */
-    public Map<Profile, Map<ArtifactRef, Dependency>> getResolvedProfileDependencies(MavenSessionHandler session)
+    public Map<Profile, Map<ArtifactRef, Dependency>> getResolvedProfileDependencies()
             throws ManipulationException {
         Map<Profile, Map<ArtifactRef, Dependency>> resolvedProfileDependencies = new HashMap<>();
 
@@ -289,11 +288,10 @@ public class Project {
      * Model as it is the same object, if you wish to remove or add items to the Model then you
      * must use {@link #getModel()}
      *
-     * @param session MavenSessionHandler, used by {@link PropertyResolver}
      * @return a list of fully resolved {@link ArtifactRef} to the original {@link Dependency}
      * @throws ManipulationException if an error occurs
      */
-    public Map<Profile, Map<ArtifactRef, Dependency>> getAllResolvedProfileDependencies(MavenSessionHandler session)
+    public Map<Profile, Map<ArtifactRef, Dependency>> getAllResolvedProfileDependencies()
             throws ManipulationException {
         Map<Profile, Map<ArtifactRef, Dependency>> allResolvedProfileDependencies = new HashMap<>();
 
@@ -314,12 +312,11 @@ public class Project {
      * reference returned will be reflected in the Model as it is the same object, if you wish to remove or add items
      * to the Model then you must use {@link #getModel()}
      *
-     * @param session MavenSessionHandler, used by {@link PropertyResolver}
      * @return a list of fully resolved {@link ArtifactRef} to the original {@link Dependency} (that were within
      *         DependencyManagement)
      * @throws ManipulationException if an error occurs
      */
-    public Map<Profile, Map<ArtifactRef, Dependency>> getResolvedProfileManagedDependencies(MavenSessionHandler session)
+    public Map<Profile, Map<ArtifactRef, Dependency>> getResolvedProfileManagedDependencies()
             throws ManipulationException {
         Map<Profile, Map<ArtifactRef, Dependency>> resolvedProfileManagedDependencies = new HashMap<>();
 
@@ -342,11 +339,10 @@ public class Project {
      * while updating the {@link Plugin} reference returned will be reflected in the Model as it is the
      * same object, if you wish to remove or add items to the Model then you must use {@link #getModel()}
      *
-     * @param session MavenSessionHandler, used by {@link PropertyResolver}
      * @return a list of fully resolved {@link ProjectVersionRef} to the original {@link Plugin}
      * @throws ManipulationException if an error occurs
      */
-    public Map<ProjectVersionRef, Plugin> getResolvedPlugins(MavenSessionHandler session) throws ManipulationException {
+    public Map<ProjectVersionRef, Plugin> getResolvedPlugins() throws ManipulationException {
         Map<ProjectVersionRef, Plugin> resolvedPlugins = new HashMap<>();
 
         if (getModel().getBuild() != null) {
@@ -361,11 +357,10 @@ public class Project {
      * list. Note that while updating the {@link Plugin} reference returned will be reflected in the Model as it is the
      * same object, if you wish to remove or add items to the Model then you must use {@link #getModel()}
      *
-     * @param session MavenSessionHandler, used by {@link PropertyResolver}
      * @return a list of fully resolved {@link ProjectVersionRef} to the original {@link Plugin}
      * @throws ManipulationException if an error occurs
      */
-    public Map<ProjectVersionRef, Plugin> getAllResolvedPlugins(MavenSessionHandler session)
+    public Map<ProjectVersionRef, Plugin> getAllResolvedPlugins()
             throws ManipulationException {
         Map<ProjectVersionRef, Plugin> resolvedPlugins = new HashMap<>();
 
@@ -382,11 +377,10 @@ public class Project {
      * the Model as it is the same object, if you wish to remove or add items to the Model then you must
      * use {@link #getModel()}
      *
-     * @param session MavenSessionHandler, used by {@link PropertyResolver}
      * @return a list of fully resolved {@link ProjectVersionRef} to the original {@link Plugin}
      * @throws ManipulationException if an error occurs
      */
-    public Map<ProjectVersionRef, Plugin> getResolvedManagedPlugins(MavenSessionHandler session)
+    public Map<ProjectVersionRef, Plugin> getResolvedManagedPlugins()
             throws ManipulationException {
         Map<ProjectVersionRef, Plugin> resolvedManagedPlugins = new HashMap<>();
 
@@ -406,11 +400,10 @@ public class Project {
      * returned will be reflected in the Model as it is the same object, if you wish to
      * remove or add items to the Model then you must use {@link #getModel()}
      *
-     * @param session MavenSessionHandler, used by {@link PropertyResolver}
      * @return a list of fully resolved {@link ProjectVersionRef} to the original {@link Plugin}
      * @throws ManipulationException if an error occurs
      */
-    public Map<Profile, Map<ProjectVersionRef, Plugin>> getResolvedProfilePlugins(MavenSessionHandler session)
+    public Map<Profile, Map<ProjectVersionRef, Plugin>> getResolvedProfilePlugins()
             throws ManipulationException {
         Map<Profile, Map<ProjectVersionRef, Plugin>> resolvedProfilePlugins = new HashMap<>();
 
@@ -433,11 +426,10 @@ public class Project {
      * reflected in the Model as it is the same object, if you wish to remove or add items to the Model then you must
      * use {@link #getModel()}
      *
-     * @param session MavenSessionHandler, used by {@link PropertyResolver}
      * @return a list of fully resolved {@link ProjectVersionRef} to the original {@link Plugin}
      * @throws ManipulationException if an error occurs
      */
-    public Map<Profile, Map<ProjectVersionRef, Plugin>> getAllResolvedProfilePlugins(MavenSessionHandler session)
+    public Map<Profile, Map<ProjectVersionRef, Plugin>> getAllResolvedProfilePlugins()
             throws ManipulationException {
         Map<Profile, Map<ProjectVersionRef, Plugin>> allResolvedProfilePlugins = new HashMap<>();
 
@@ -460,11 +452,10 @@ public class Project {
      * reference returned will be reflected in the Model as it is the same object, if you wish to remove
      * or add items to the Model then you must use {@link #getModel()}
      *
-     * @param session MavenSessionHandler, used by {@link PropertyResolver}
      * @return a list of fully resolved {@link ProjectVersionRef} to the original {@link Plugin}
      * @throws ManipulationException if an error occurs
      */
-    public Map<Profile, Map<ProjectVersionRef, Plugin>> getResolvedProfileManagedPlugins(MavenSessionHandler session)
+    public Map<Profile, Map<ProjectVersionRef, Plugin>> getResolvedProfileManagedPlugins()
             throws ManipulationException {
         Map<Profile, Map<ProjectVersionRef, Plugin>> resolvedProfileManagedPlugins = new HashMap<>();
 
@@ -490,11 +481,10 @@ public class Project {
      * Note that while updating the {@link Dependency} reference returned will be reflected in the Model
      * as it is the same object, if you wish to remove or add items to the Model then you must use {@link #getModel()}
      *
-     * @param session MavenSessionHandler, used by {@link PropertyResolver}
      * @return a list of fully resolved {@link ArtifactRef} to the original {@link Dependency}
      * @throws ManipulationException if an error occurs
      */
-    public Map<ArtifactRef, Dependency> getResolvedDependencies(MavenSessionHandler session)
+    public Map<ArtifactRef, Dependency> getResolvedDependencies()
             throws ManipulationException {
         Map<ArtifactRef, Dependency> resolvedDependencies = new HashMap<>();
 
@@ -511,11 +501,10 @@ public class Project {
      * Note that while updating the {@link Dependency} reference returned will be reflected in the Model
      * as it is the same object, if you wish to remove or add items to the Model then you must use {@link #getModel()}
      *
-     * @param session MavenSessionHandler, used by {@link PropertyResolver}
      * @return a list of fully resolved {@link ArtifactRef} to the original {@link Dependency}
      * @throws ManipulationException if an error occurs
      */
-    public Map<ArtifactRef, Dependency> getAllResolvedDependencies(MavenSessionHandler session)
+    public Map<ArtifactRef, Dependency> getAllResolvedDependencies()
             throws ManipulationException {
         Map<ArtifactRef, Dependency> allResolvedDependencies = new HashMap<>();
 
@@ -534,11 +523,10 @@ public class Project {
      * Note that while updating the {@link Dependency} reference returned will be reflected in the Model
      * as it is the same object, if you wish to remove or add items to the Model then you must use {@link #getModel()}
      *
-     * @param session MavenSessionHandler, used by {@link PropertyResolver}
      * @return a list containing maps of fully resolved {@link ArtifactRef} to the original {@link Dependency}
      * @throws ManipulationException if an error occurs
      */
-    public List<Map<ArtifactRef, Dependency>> getAllResolvedPluginDependencies(MavenSessionHandler session)
+    public List<Map<ArtifactRef, Dependency>> getAllResolvedPluginDependencies()
             throws ManipulationException {
         List<Map<ArtifactRef, Dependency>> allResolvedDependencies = new ArrayList<>();
 
@@ -581,12 +569,11 @@ public class Project {
      * in the Model as it is the same object, if you wish to remove or add items to the Model then you must use
      * {@link #getModel()}
      *
-     * @param session MavenSessionHandler, used by {@link PropertyResolver}
      * @return a list of fully resolved {@link ArtifactRef} to the original {@link Dependency} (that were within
      *         DependencyManagement)
      * @throws ManipulationException if an error occurs
      */
-    public Map<ArtifactRef, Dependency> getResolvedManagedDependencies(MavenSessionHandler session)
+    public Map<ArtifactRef, Dependency> getResolvedManagedDependencies()
             throws ManipulationException {
         Map<ArtifactRef, Dependency> resolvedManagedDependencies = new HashMap<>();
 

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/model/Project.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/model/Project.java
@@ -93,7 +93,19 @@ public class Project {
      */
     private Project projectParent;
 
-    public Project(final File pom, final Model model) throws ManipulationException {
+    /**
+     * Maven session context for this project (may be null, e.g. in tests).
+     */
+    private final MavenSessionHandler session;
+
+    /**
+     * @param sessionHandler Maven session context (may be null, e.g. in unit tests)
+     * @param pom POM file for this project
+     * @param model model to manipulate
+     */
+    public Project(final MavenSessionHandler sessionHandler, final File pom, final Model model)
+            throws ManipulationException {
+        this.session = sessionHandler;
         this.pom = pom;
         this.model = model;
 
@@ -113,16 +125,17 @@ public class Project {
      */
     public Project(final Model model)
             throws ManipulationException {
-        this(model.getPomFile(), model);
+        this(null, model.getPomFile(), model);
     }
 
     /**
-     * Create a project by copying another.
+     * Create a project by copying another. Only used by ManipulationManager for comparing changes.
      *
      * @param original the Project to use.
      */
     @SuppressWarnings("IncompleteCopyConstructor")
     public Project(final Project original) {
+        this.session = original.session;
         this.pom = original.pom;
         this.model = original.model.clone();
         this.inheritanceRoot = original.inheritanceRoot;

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/model/Project.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/model/Project.java
@@ -93,7 +93,19 @@ public class Project {
      */
     private Project projectParent;
 
-    public Project(final File pom, final Model model) throws ManipulationException {
+    /**
+     * Maven session context for this project (may be null, e.g. in tests).
+     */
+    private final MavenSessionHandler session;
+
+    /**
+     * @param sessionHandler Maven session context (may be null, e.g. in unit tests)
+     * @param pom POM file for this project
+     * @param model model to manipulate
+     */
+    public Project(final MavenSessionHandler sessionHandler, final File pom, final Model model)
+            throws ManipulationException {
+        this.session = sessionHandler;
         this.pom = pom;
         this.model = model;
 
@@ -113,16 +125,17 @@ public class Project {
      */
     public Project(final Model model)
             throws ManipulationException {
-        this(model.getPomFile(), model);
+        this(null, model.getPomFile(), model);
     }
 
     /**
-     * Create a project by copying another.
+     * Create a project by copying another. Only used by ManipulationManager for comparing changes.
      *
      * @param original the Project to use.
      */
     @SuppressWarnings("IncompleteCopyConstructor")
     public Project(final Project original) {
+        this.session = original.session;
         this.pom = original.pom;
         this.model = original.model.clone();
         this.inheritanceRoot = original.inheritanceRoot;
@@ -193,7 +206,11 @@ public class Project {
     }
 
     public ProjectVersionRef getKey() {
-        return new SimpleProjectVersionRef(getGroupId(), getArtifactId(), getVersion());
+        return new SimpleProjectVersionRef(
+                getGroupId(),
+                getArtifactId(),
+                getVersion());
+
     }
 
     public Parent getModelParent() {
@@ -212,7 +229,10 @@ public class Project {
             // Note: reliant upon model validation that the parent is not null.
             g = model.getParent().getGroupId();
         }
-        return g;
+        return PropertyResolver.resolvePropertiesUnchecked(
+                session,
+                getInheritedList(),
+                g);
     }
 
     /**
@@ -221,7 +241,10 @@ public class Project {
      * @return the artifactId
      */
     public String getArtifactId() {
-        return getModel().getArtifactId();
+        return PropertyResolver.resolvePropertiesUnchecked(
+                session,
+                getInheritedList(),
+                getModel().getArtifactId());
     }
 
     /**
@@ -236,7 +259,10 @@ public class Project {
             // Note: reliant upon model validation that the parent is not null.
             v = model.getParent().getVersion();
         }
-        return v;
+        return PropertyResolver.resolvePropertiesUnchecked(
+                session,
+                getInheritedList(),
+                v);
     }
 
     /**

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/ProfileUtils.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/ProfileUtils.java
@@ -41,8 +41,8 @@ public final class ProfileUtils {
     public static List<Profile> getProfiles(MavenSessionHandler session, Model model) {
         final List<Profile> result = new ArrayList<>();
         final List<Profile> profiles = model.getProfiles();
-        final boolean scanActiveProfiles = Boolean
-                .parseBoolean(session.getUserProperties().getProperty(PROFILE_SCANNING, PROFILE_SCANNING_DEFAULT));
+        final boolean scanActiveProfiles = (session != null && Boolean
+                .parseBoolean(session.getUserProperties().getProperty(PROFILE_SCANNING, PROFILE_SCANNING_DEFAULT)));
 
         if (profiles != null) {
             if (scanActiveProfiles) {

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/ProjectComparator.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/ProjectComparator.java
@@ -126,10 +126,11 @@ public class ProjectComparator {
 
                                 ModulesItem module = new ModulesItem();
                                 modules.add(module);
+                                ProjectVersionRef pvr = newProject.getKey();
                                 module.getGav().setOriginalGAV(originalProject.getKey().toString());
-                                module.getGav().setPVR(newProject.getKey());
+                                module.getGav().setPVR(pvr);
 
-                                append(builder, "------------------- project {}", newProject.getKey().asProjectRef());
+                                append(builder, "------------------- project {}", pvr.asProjectRef());
                                 if (!originalProject.getVersion().equals(newProject.getVersion())) {
                                     append(
                                             builder,

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/ProjectComparator.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/ProjectComparator.java
@@ -126,8 +126,8 @@ public class ProjectComparator {
 
                                 ModulesItem module = new ModulesItem();
                                 modules.add(module);
-                                ProjectVersionRef pvr = newProject.getKey();
-                                module.getGav().setOriginalGAV(originalProject.getKey().toString());
+                                ProjectVersionRef pvr = newProject.getResolvedKey();
+                                module.getGav().setOriginalGAV(originalProject.getResolvedKey().toString());
                                 module.getGav().setPVR(pvr);
 
                                 append(builder, "------------------- project {}", pvr.asProjectRef());

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/ProjectComparator.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/ProjectComparator.java
@@ -504,30 +504,30 @@ public class ProjectComparator {
         try {
             switch (type) {
                 case DEPENDENCIES: {
-                    return project.getResolvedDependencies(session).keySet();
+                    return project.getResolvedDependencies().keySet();
                 }
                 case MANAGED_DEPENDENCIES: {
-                    return project.getResolvedManagedDependencies(session).keySet();
+                    return project.getResolvedManagedDependencies().keySet();
                 }
                 case PROFILE_DEPENDENCIES: {
-                    return project.getResolvedProfileDependencies(session)
+                    return project.getResolvedProfileDependencies()
                             .getOrDefault(profile, Collections.emptyMap())
                             .keySet();
                 }
                 case PROFILE_MANAGED_DEPENDENCIES: {
-                    return project.getResolvedProfileManagedDependencies(session)
+                    return project.getResolvedProfileManagedDependencies()
                             .getOrDefault(profile, Collections.emptyMap())
                             .keySet();
                 }
                 case DEPENDENCIES_UNVERSIONED: {
-                    return project.getAllResolvedDependencies(session)
+                    return project.getAllResolvedDependencies()
                             .keySet()
                             .stream()
                             .filter(a -> a.getVersionString().equals("*"))
                             .collect(Collectors.toSet());
                 }
                 case PROFILE_DEPENDENCIES_UNVERSIONED: {
-                    return project.getAllResolvedProfileDependencies(session)
+                    return project.getAllResolvedProfileDependencies()
                             .getOrDefault(profile, Collections.emptyMap())
                             .keySet()
                             .stream()
@@ -552,18 +552,18 @@ public class ProjectComparator {
         try {
             switch (type) {
                 case PLUGINS: {
-                    return project.getResolvedPlugins(session).keySet();
+                    return project.getResolvedPlugins().keySet();
                 }
                 case MANAGED_PLUGINS: {
-                    return project.getResolvedManagedPlugins(session).keySet();
+                    return project.getResolvedManagedPlugins().keySet();
                 }
                 case PROFILE_PLUGINS: {
-                    return project.getResolvedProfilePlugins(session)
+                    return project.getResolvedProfilePlugins()
                             .getOrDefault(profile, Collections.emptyMap())
                             .keySet();
                 }
                 case PROFILE_MANAGED_PLUGINS: {
-                    return project.getResolvedProfileManagedPlugins(session)
+                    return project.getResolvedProfileManagedPlugins()
                             .getOrDefault(profile, Collections.emptyMap())
                             .keySet();
                 }

--- a/common/src/test/java/org/jboss/pnc/mavenmanipulator/common/model/ProjectTest.java
+++ b/common/src/test/java/org/jboss/pnc/mavenmanipulator/common/model/ProjectTest.java
@@ -33,7 +33,7 @@ public class ProjectTest {
 
     @Test(expected = ManipulationException.class)
     public void createProjectWithNullModel() throws ManipulationException {
-        new Project(null, null);
+        new Project(null, null, null);
     }
 
     @Test

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/ManipulationManager.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/ManipulationManager.java
@@ -224,7 +224,7 @@ public class ManipulationManager {
                     session.getPom());
         }
 
-        final List<Project> currentProjects = pomIO.parseProject(session.getPom());
+        final List<Project> currentProjects = pomIO.parseProject(session, session.getPom());
         final List<Project> originalProjects = new ArrayList<>();
         currentProjects.forEach(p -> originalProjects.add(new Project(p)));
 

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/ManipulationManager.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/ManipulationManager.java
@@ -224,7 +224,7 @@ public class ManipulationManager {
                     session.getPom());
         }
 
-        final List<Project> currentProjects = pomIO.parseProject(session.getPom());
+        final List<Project> currentProjects = pomIO.parseProject(session, session.getPom());
         final List<Project> originalProjects = new ArrayList<>();
         currentProjects.forEach(p -> originalProjects.add(new Project(p)));
 
@@ -243,8 +243,11 @@ public class ManipulationManager {
             logger.info("Maven-Manipulation-Extension: Completed with changed: {}", currentProjects);
 
             Optional<Project> newExecutionRoot = changed.stream().filter(Project::isExecutionRoot).findFirst();
-            newExecutionRoot.ifPresent(project -> jsonReport.getGav().setPVR(project.getKey()));
-            jsonReport.getGav().setOriginalGAV(originalExecutionRoot.getKey().toString());
+            newExecutionRoot.ifPresent(
+                    project -> jsonReport.getGav()
+                            .setPVR(project.getKey()));
+            jsonReport.getGav()
+                    .setOriginalGAV(originalExecutionRoot.getKey().toString());
 
             WildcardMap<ProjectVersionRef> map = (session.getState(RelocationState.class) == null ? new WildcardMap<>()
                     : session.getState(RelocationState.class).getDependencyRelocations());

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/ManipulationManager.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/ManipulationManager.java
@@ -243,8 +243,8 @@ public class ManipulationManager {
             logger.info("Maven-Manipulation-Extension: Completed with changed: {}", currentProjects);
 
             Optional<Project> newExecutionRoot = changed.stream().filter(Project::isExecutionRoot).findFirst();
-            newExecutionRoot.ifPresent(project -> jsonReport.getGav().setPVR(project.getKey()));
-            jsonReport.getGav().setOriginalGAV(originalExecutionRoot.getKey().toString());
+            newExecutionRoot.ifPresent(project -> jsonReport.getGav().setPVR(project.getResolvedKey()));
+            jsonReport.getGav().setOriginalGAV(originalExecutionRoot.getResolvedKey().toString());
 
             WildcardMap<ProjectVersionRef> map = (session.getState(RelocationState.class) == null ? new WildcardMap<>()
                     : session.getState(RelocationState.class).getDependencyRelocations());

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/BaseScriptUtils.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/BaseScriptUtils.java
@@ -56,7 +56,7 @@ public abstract class BaseScriptUtils extends Script implements MavenBaseScript 
     public void inlineProperty(Project currentProject, ProjectRef groupArtifact) throws ManipulationException {
         logger.debug("Inlining property for {} with reference {}", currentProject, groupArtifact);
         try {
-            currentProject.getResolvedManagedDependencies(getSession())
+            currentProject.getResolvedManagedDependencies()
                     .entrySet()
                     .stream()
                     .filter(
@@ -73,7 +73,7 @@ public abstract class BaseScriptUtils extends Script implements MavenBaseScript 
                                                 currentProject.getInheritedList(),
                                                 a.getValue().getVersion()));
                     });
-            currentProject.getResolvedDependencies(getSession())
+            currentProject.getResolvedDependencies()
                     .entrySet()
                     .stream()
                     .filter(
@@ -90,7 +90,7 @@ public abstract class BaseScriptUtils extends Script implements MavenBaseScript 
                                                 currentProject.getInheritedList(),
                                                 a.getValue().getVersion()));
                     });
-            currentProject.getResolvedManagedPlugins(getSession())
+            currentProject.getResolvedManagedPlugins()
                     .entrySet()
                     .stream()
                     .filter(
@@ -107,7 +107,7 @@ public abstract class BaseScriptUtils extends Script implements MavenBaseScript 
                                                 currentProject.getInheritedList(),
                                                 a.getValue().getVersion()));
                     });
-            currentProject.getResolvedPlugins(getSession())
+            currentProject.getResolvedPlugins()
                     .entrySet()
                     .stream()
                     .filter(
@@ -141,7 +141,7 @@ public abstract class BaseScriptUtils extends Script implements MavenBaseScript 
     public void inlineProperty(Project currentProject, String propertyKey) throws ManipulationException {
         logger.debug("Inlining property for {} with reference {}", currentProject, propertyKey);
         try {
-            currentProject.getResolvedManagedDependencies(getSession())
+            currentProject.getResolvedManagedDependencies()
                     .entrySet()
                     .stream()
                     .filter(a -> a.getValue().getVersion().equals("${" + propertyKey + "}"))
@@ -154,7 +154,7 @@ public abstract class BaseScriptUtils extends Script implements MavenBaseScript 
                                                 currentProject.getInheritedList(),
                                                 a.getValue().getVersion()));
                     });
-            currentProject.getResolvedDependencies(getSession())
+            currentProject.getResolvedDependencies()
                     .entrySet()
                     .stream()
                     .filter(a -> a.getValue().getVersion().equals("${" + propertyKey + "}"))
@@ -167,7 +167,7 @@ public abstract class BaseScriptUtils extends Script implements MavenBaseScript 
                                                 currentProject.getInheritedList(),
                                                 a.getValue().getVersion()));
                     });
-            currentProject.getResolvedManagedPlugins(getSession())
+            currentProject.getResolvedManagedPlugins()
                     .entrySet()
                     .stream()
                     .filter(
@@ -182,7 +182,7 @@ public abstract class BaseScriptUtils extends Script implements MavenBaseScript 
                                                 currentProject.getInheritedList(),
                                                 a.getValue().getVersion()));
                     });
-            currentProject.getResolvedPlugins(getSession())
+            currentProject.getResolvedPlugins()
                     .entrySet()
                     .stream()
                     .filter(a -> a.getValue().getVersion().equals("${" + propertyKey + "}"))

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/DependencyManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/DependencyManipulator.java
@@ -251,8 +251,8 @@ public class DependencyManipulator extends CommonManipulator implements Manipula
             if (cState.getStrictDependencyPluginPropertyValidation() > 0) {
                 logger.info("Iterating to validate dependency updates...");
                 for (final Project p : versionPropertyUpdateMap.keySet()) {
-                    validateDependenciesUpdatedProperty(cState, p, p.getResolvedDependencies(session));
-                    for (final Map<ArtifactRef, Dependency> dependencies : p.getResolvedProfileDependencies(session)
+                    validateDependenciesUpdatedProperty(cState, p, p.getResolvedDependencies());
+                    for (final Map<ArtifactRef, Dependency> dependencies : p.getResolvedProfileDependencies()
                             .values()) {
                         validateDependenciesUpdatedProperty(cState, p, dependencies);
                     }
@@ -384,13 +384,13 @@ public class DependencyManipulator extends CommonManipulator implements Manipula
 
             final Map<ArtifactRef, String> nonMatchingVersionOverrides = applyOverrides(
                     project,
-                    project.getResolvedManagedDependencies(session),
+                    project.getResolvedManagedDependencies(),
                     explicitOverrides,
                     originalOverrides);
 
             applyExplicitOverrides(
                     project,
-                    project.getResolvedManagedDependencies(session),
+                    project.getResolvedManagedDependencies(),
                     explicitOverrides,
                     explicitVersionPropertyUpdateMap);
 
@@ -441,27 +441,27 @@ public class DependencyManipulator extends CommonManipulator implements Manipula
             logger.debug("Applying overrides to managed dependencies for: {}", projectGA);
             applyOverrides(
                     project,
-                    project.getResolvedManagedDependencies(session),
+                    project.getResolvedManagedDependencies(),
                     explicitOverrides,
                     originalOverrides);
             applyExplicitOverrides(
                     project,
-                    project.getResolvedManagedDependencies(session),
+                    project.getResolvedManagedDependencies(),
                     explicitOverrides,
                     explicitVersionPropertyUpdateMap);
         }
 
         logger.debug("Applying overrides to concrete dependencies for: {}", projectGA);
         // Apply overrides to project direct dependencies
-        applyOverrides(project, project.getResolvedDependencies(session), explicitOverrides, originalOverrides);
+        applyOverrides(project, project.getResolvedDependencies(), explicitOverrides, originalOverrides);
         applyExplicitOverrides(
                 project,
-                project.getResolvedDependencies(session),
+                project.getResolvedDependencies(),
                 explicitOverrides,
                 explicitVersionPropertyUpdateMap);
 
-        final Map<Profile, Map<ArtifactRef, Dependency>> pd = project.getResolvedProfileDependencies(session);
-        final Map<Profile, Map<ArtifactRef, Dependency>> pmd = project.getResolvedProfileManagedDependencies(session);
+        final Map<Profile, Map<ArtifactRef, Dependency>> pd = project.getResolvedProfileDependencies();
+        final Map<Profile, Map<ArtifactRef, Dependency>> pmd = project.getResolvedProfileManagedDependencies();
 
         for (final Map<ArtifactRef, Dependency> dependencies : pd.values()) {
             applyOverrides(project, dependencies, explicitOverrides, originalOverrides);
@@ -474,15 +474,15 @@ public class DependencyManipulator extends CommonManipulator implements Manipula
         }
 
         // Apply dependency changes to dependencies that occur within plugins.
-        final Map<ProjectVersionRef, Plugin> resolvedPlugins = project.getAllResolvedPlugins(session);
+        final Map<ProjectVersionRef, Plugin> resolvedPlugins = project.getAllResolvedPlugins();
         applyPlugins(project, resolvedPlugins, explicitOverrides, originalOverrides);
         applyExplicitOverrides(project, resolvedPlugins, explicitOverrides, explicitVersionPropertyUpdateMap);
 
-        final Map<ProjectVersionRef, Plugin> resolvedManagedPlugins = project.getResolvedManagedPlugins(session);
+        final Map<ProjectVersionRef, Plugin> resolvedManagedPlugins = project.getResolvedManagedPlugins();
         applyPlugins(project, resolvedManagedPlugins, explicitOverrides, originalOverrides);
         applyExplicitOverrides(project, resolvedManagedPlugins, explicitOverrides, explicitVersionPropertyUpdateMap);
 
-        for (Map<ProjectVersionRef, Plugin> resolvedProfilePlugins : project.getAllResolvedProfilePlugins(session)
+        for (Map<ProjectVersionRef, Plugin> resolvedProfilePlugins : project.getAllResolvedProfilePlugins()
                 .values()) {
             applyPlugins(project, resolvedProfilePlugins, explicitOverrides, originalOverrides);
             applyExplicitOverrides(
@@ -492,7 +492,7 @@ public class DependencyManipulator extends CommonManipulator implements Manipula
                     explicitVersionPropertyUpdateMap);
         }
         for (Map<ProjectVersionRef, Plugin> resolvedManagedProfilePlugins : project
-                .getResolvedProfileManagedPlugins(session)
+                .getResolvedProfileManagedPlugins()
                 .values()) {
             applyPlugins(project, resolvedManagedProfilePlugins, explicitOverrides, originalOverrides);
             applyExplicitOverrides(
@@ -503,7 +503,7 @@ public class DependencyManipulator extends CommonManipulator implements Manipula
         }
 
         // This handles dependencies of plugins themselves.
-        final List<Map<ArtifactRef, Dependency>> pluginDependencies = project.getAllResolvedPluginDependencies(session);
+        final List<Map<ArtifactRef, Dependency>> pluginDependencies = project.getAllResolvedPluginDependencies();
         for (Map<ArtifactRef, Dependency> depMap : pluginDependencies) {
             applyOverrides(project, depMap, explicitOverrides, originalOverrides);
             applyExplicitOverrides(project, depMap, explicitOverrides, explicitVersionPropertyUpdateMap);

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/DependencyRemovalManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/DependencyRemovalManipulator.java
@@ -98,20 +98,20 @@ public class DependencyRemovalManipulator
 
         List<ProjectRef> dependenciesToRemove = state.getDependencyRemoval();
         boolean result = scanDependencies(
-                project.getAllResolvedDependencies(session),
+                project.getAllResolvedDependencies(),
                 dependenciesToRemove,
                 model.getDependencies());
 
         if (model.getDependencyManagement() != null &&
                 scanDependencies(
-                        project.getResolvedManagedDependencies(session),
+                        project.getResolvedManagedDependencies(),
                         dependenciesToRemove,
                         model.getDependencyManagement().getDependencies())) {
             result = true;
         }
 
-        final Map<Profile, Map<ArtifactRef, Dependency>> pd = project.getAllResolvedProfileDependencies(session);
-        final Map<Profile, Map<ArtifactRef, Dependency>> pmd = project.getResolvedProfileManagedDependencies(session);
+        final Map<Profile, Map<ArtifactRef, Dependency>> pd = project.getAllResolvedProfileDependencies();
+        final Map<Profile, Map<ArtifactRef, Dependency>> pmd = project.getResolvedProfileManagedDependencies();
         for (final Entry<Profile, Map<ArtifactRef, Dependency>> entry : pd.entrySet()) {
             final Profile profile = entry.getKey();
             final Map<ArtifactRef, Dependency> resolvedDependencies = entry.getValue();

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/PluginManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/PluginManipulator.java
@@ -142,8 +142,8 @@ public class PluginManipulator extends CommonManipulator implements Manipulator 
             if (cState.getStrictDependencyPluginPropertyValidation() > 0) {
                 logger.info("Iterating to validate plugin updates...");
                 for (final Project p : versionPropertyUpdateMap.keySet()) {
-                    validatePluginsUpdatedProperty(cState, p, p.getResolvedPlugins(session));
-                    for (final Map<ProjectVersionRef, Plugin> dependencies : p.getResolvedProfilePlugins(session)
+                    validatePluginsUpdatedProperty(cState, p, p.getResolvedPlugins());
+                    for (final Map<ProjectVersionRef, Plugin> dependencies : p.getResolvedProfilePlugins()
                             .values()) {
                         validatePluginsUpdatedProperty(cState, p, dependencies);
                     }
@@ -291,23 +291,23 @@ public class PluginManipulator extends CommonManipulator implements Manipulator 
             }
 
             // Override plugin management versions
-            applyOverrides(project, PluginType.LocalPM, project.getResolvedManagedPlugins(session), overrides);
+            applyOverrides(project, PluginType.LocalPM, project.getResolvedManagedPlugins(), overrides);
         }
 
-        applyOverrides(project, PluginType.LocalP, project.getResolvedPlugins(session), overrides);
+        applyOverrides(project, PluginType.LocalP, project.getResolvedPlugins(), overrides);
         applyExplicitOverrides(
                 project,
-                project.getResolvedPlugins(session),
+                project.getResolvedPlugins(),
                 explicitOverrides,
                 explicitVersionPropertyUpdateMap);
         applyExplicitOverrides(
                 project,
-                project.getResolvedManagedPlugins(session),
+                project.getResolvedManagedPlugins(),
                 explicitOverrides,
                 explicitVersionPropertyUpdateMap);
 
-        final Map<Profile, Map<ProjectVersionRef, Plugin>> pd = project.getResolvedProfilePlugins(session);
-        final Map<Profile, Map<ProjectVersionRef, Plugin>> pmd = project.getResolvedProfileManagedPlugins(session);
+        final Map<Profile, Map<ProjectVersionRef, Plugin>> pd = project.getResolvedProfilePlugins();
+        final Map<Profile, Map<ProjectVersionRef, Plugin>> pmd = project.getResolvedProfileManagedPlugins();
 
         logger.debug("Processing profiles with plugin management");
         for (final Map<ProjectVersionRef, Plugin> plugins : pmd.values()) {

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/RESTCollector.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/RESTCollector.java
@@ -91,7 +91,7 @@ public class RESTCollector
         for (final Project project : projects) {
             if (isEmpty(override)) {
                 // Strip SNAPSHOT and handle OSGi and alternate suffixes from the version for matching.
-                ProjectVersionRef pvr = project.getKey();
+                ProjectVersionRef pvr = project.getResolvedKey();
                 restLookupProjectVersionParamList.add(
                         new SimpleProjectVersionRef(
                                 pvr.asProjectRef(),

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/RESTCollector.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/RESTCollector.java
@@ -91,13 +91,16 @@ public class RESTCollector
         for (final Project project : projects) {
             if (isEmpty(override)) {
                 // Strip SNAPSHOT and handle OSGi and alternate suffixes from the version for matching.
+                ProjectVersionRef pvr = project.getKey();
                 restLookupProjectVersionParamList.add(
                         new SimpleProjectVersionRef(
-                                project.getKey().asProjectRef(),
+                                pvr.asProjectRef(),
                                 handlePotentialSnapshotVersion(
                                         vs,
                                         Version.getOsgiVersion(
-                                                VersionCalculator.handleAlternate(vs, project.getVersion())))));
+                                                VersionCalculator.handleAlternate(
+                                                        vs,
+                                                        pvr.getVersionString())))));
             } else if (project.isExecutionRoot()) {
                 // We want to manually override the version ; therefore ignore what is in the project and calculate potential
                 // matches for that instead.

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/RESTCollector.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/RESTCollector.java
@@ -236,10 +236,10 @@ public class RESTCollector
                     localDeps.add(new SimpleScopedArtifactRef(parent, new SimpleTypeAndClassifier("pom", null), null));
                 }
 
-                recordDependencies(session, localDeps, project.getResolvedManagedDependencies(session));
-                recordDependencies(session, localDeps, project.getResolvedDependencies(session));
-                recordPlugins(session, localDeps, project.getResolvedManagedPlugins(session));
-                recordPlugins(session, localDeps, project.getResolvedPlugins(session));
+                recordDependencies(session, localDeps, project.getResolvedManagedDependencies());
+                recordDependencies(session, localDeps, project.getResolvedDependencies());
+                recordPlugins(session, localDeps, project.getResolvedManagedPlugins());
+                recordPlugins(session, localDeps, project.getResolvedPlugins());
 
                 List<Profile> profiles = project.getModel().getProfiles();
                 if (profiles != null) {
@@ -250,22 +250,22 @@ public class RESTCollector
                         recordDependencies(
                                 session,
                                 localDeps,
-                                project.getResolvedProfileManagedDependencies(session)
+                                project.getResolvedProfileManagedDependencies()
                                         .getOrDefault(p, Collections.emptyMap()));
                         recordDependencies(
                                 session,
                                 localDeps,
-                                project.getResolvedProfileDependencies(session)
+                                project.getResolvedProfileDependencies()
                                         .getOrDefault(p, Collections.emptyMap()));
                         recordPlugins(
                                 session,
                                 localDeps,
-                                project.getResolvedProfileManagedPlugins(session)
+                                project.getResolvedProfileManagedPlugins()
                                         .getOrDefault(p, Collections.emptyMap()));
                         recordPlugins(
                                 session,
                                 localDeps,
-                                project.getResolvedProfilePlugins(session).getOrDefault(p, Collections.emptyMap()));
+                                project.getResolvedProfilePlugins().getOrDefault(p, Collections.emptyMap()));
 
                     }
                 }

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/RelocationManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/RelocationManipulator.java
@@ -128,9 +128,9 @@ public class RelocationManipulator
             result = updateDependencies(
                     project,
                     dependencyRelocations,
-                    project.getResolvedManagedDependencies(session));
+                    project.getResolvedManagedDependencies());
         }
-        result |= updateDependencies(project, dependencyRelocations, project.getAllResolvedDependencies(session));
+        result |= updateDependencies(project, dependencyRelocations, project.getAllResolvedDependencies());
 
         for (final Profile profile : ProfileUtils.getProfiles(session, model)) {
             dependencyManagement = profile.getDependencyManagement();
@@ -138,12 +138,12 @@ public class RelocationManipulator
                 result |= updateDependencies(
                         project,
                         dependencyRelocations,
-                        project.getResolvedProfileManagedDependencies(session).get(profile));
+                        project.getResolvedProfileManagedDependencies().get(profile));
             }
             result |= updateDependencies(
                     project,
                     dependencyRelocations,
-                    project.getAllResolvedProfileDependencies(session).get(profile));
+                    project.getAllResolvedProfileDependencies().get(profile));
 
         }
 
@@ -151,28 +151,28 @@ public class RelocationManipulator
                 pluginRelocations,
                 dependencyRelocations,
                 project,
-                project.getResolvedManagedPlugins(session));
+                project.getResolvedManagedPlugins());
 
         result |= updatePlugins(
                 pluginRelocations,
                 dependencyRelocations,
                 project,
-                project.getAllResolvedPlugins(session));
+                project.getAllResolvedPlugins());
 
-        for (Profile profile : project.getAllResolvedProfilePlugins(session).keySet()) {
+        for (Profile profile : project.getAllResolvedProfilePlugins().keySet()) {
             result |= updatePlugins(
                     pluginRelocations,
                     dependencyRelocations,
                     project,
-                    project.getAllResolvedProfilePlugins(session).get(profile));
+                    project.getAllResolvedProfilePlugins().get(profile));
         }
 
-        for (Profile profile : project.getResolvedProfileManagedPlugins(session).keySet()) {
+        for (Profile profile : project.getResolvedProfileManagedPlugins().keySet()) {
             result |= updatePlugins(
                     pluginRelocations,
                     dependencyRelocations,
                     project,
-                    project.getResolvedProfileManagedPlugins(session).get(profile));
+                    project.getResolvedProfileManagedPlugins().get(profile));
         }
 
         return result;

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/RepositoryInjectionManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/RepositoryInjectionManipulator.java
@@ -151,13 +151,13 @@ public class RepositoryInjectionManipulator
             for (ProjectRef p : gaToApply) {
                 if (p.getArtifactId().contains("*") && p.getGroupId().equals(project.getGroupId())) {
                     result = true;
-                } else if (p.equals(project.getKey().asProjectRef())) {
+                } else if (p.equals(project.getResolvedKey().asProjectRef())) {
                     result = true;
                 }
             }
             logger.debug(
                     "Checking project {} against possible GAs {} and found match {}",
-                    project.getKey().asProjectRef(),
+                    project.getResolvedKey().asProjectRef(),
                     gaToApply,
                     result);
         } else if (project.isInheritanceRoot()) {

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/SuffixManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/SuffixManipulator.java
@@ -111,23 +111,23 @@ public class SuffixManipulator
                 }
             }
 
-            processDependencies(suffixStripPattern, project, project.getResolvedDependencies(session));
-            processDependencies(suffixStripPattern, project, project.getResolvedManagedDependencies(session));
-            processPlugins(suffixStripPattern, project, project.getResolvedPlugins(session));
-            processPlugins(suffixStripPattern, project, project.getResolvedManagedPlugins(session));
+            processDependencies(suffixStripPattern, project, project.getResolvedDependencies());
+            processDependencies(suffixStripPattern, project, project.getResolvedManagedDependencies());
+            processPlugins(suffixStripPattern, project, project.getResolvedPlugins());
+            processPlugins(suffixStripPattern, project, project.getResolvedManagedPlugins());
 
             List<Profile> profiles = ProfileUtils.getProfiles(session, project.getModel());
             for (Profile p : profiles) {
                 processDependencies(
                         suffixStripPattern,
                         project,
-                        project.getResolvedProfileDependencies(session).get(p));
+                        project.getResolvedProfileDependencies().get(p));
                 processDependencies(
                         suffixStripPattern,
                         project,
-                        project.getResolvedProfileManagedDependencies(session).get(p));
-                processPlugins(suffixStripPattern, project, project.getResolvedProfilePlugins(session).get(p));
-                processPlugins(suffixStripPattern, project, project.getResolvedProfileManagedPlugins(session).get(p));
+                        project.getResolvedProfileManagedDependencies().get(p));
+                processPlugins(suffixStripPattern, project, project.getResolvedProfilePlugins().get(p));
+                processPlugins(suffixStripPattern, project, project.getResolvedProfileManagedPlugins().get(p));
             }
         }
         return changed;

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/groovy/BaseScriptTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/groovy/BaseScriptTest.java
@@ -198,7 +198,7 @@ public class BaseScriptTest {
 
         assertEquals(
                 "1.18.20.0",
-                root.getResolvedPlugins(bs.getSession())
+                root.getResolvedPlugins()
                         .entrySet()
                         .stream()
                         .filter(d -> d.getKey().getArtifactId().equals(pluginArtifact.getArtifactId()))
@@ -212,7 +212,7 @@ public class BaseScriptTest {
 
         assertEquals(
                 "3.5.1",
-                root.getResolvedManagedPlugins(bs.getSession())
+                root.getResolvedManagedPlugins()
                         .entrySet()
                         .stream()
                         .filter(d -> d.getKey().getArtifactId().equals(dependencyPluginArtifact.getArtifactId()))

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/groovy/BaseScriptTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/groovy/BaseScriptTest.java
@@ -74,7 +74,7 @@ public class BaseScriptTest {
         final File projectroot = new File(ROOT_DIRECTORY.toFile(), "pom.xml");
 
         PomIO pomIO = new PomIO();
-        List<Project> projects = pomIO.parseProject(projectroot);
+        List<Project> projects = pomIO.parseProject(null, projectroot);
         ManipulationSession ms = TestUtils.createSession(null, projectroot);
 
         Project root = projects.stream().filter(p -> p.getProjectParent() == null).findAny().orElse(null);
@@ -98,7 +98,7 @@ public class BaseScriptTest {
         final File projectroot = new File(ROOT_DIRECTORY.toFile(), "pom.xml");
 
         PomIO pomIO = new PomIO();
-        List<Project> projects = pomIO.parseProject(projectroot);
+        List<Project> projects = pomIO.parseProject(null, projectroot);
         ManipulationSession ms = TestUtils.createSession(null, projectroot);
 
         Project root = projects.stream().filter(p -> p.getProjectParent() == null).findAny().orElse(null);
@@ -129,7 +129,7 @@ public class BaseScriptTest {
         PomIO pomIO = new PomIO();
         FileIO fileIO = new FileIO(temporaryFolder.newFolder());
 
-        List<Project> projects = pomIO.parseProject(projectroot);
+        List<Project> projects = pomIO.parseProject(null, projectroot);
         ManipulationSession ms = TestUtils.createSession(null, projectroot);
 
         Project root = projects.stream()
@@ -228,7 +228,7 @@ public class BaseScriptTest {
         final File groovy = TestUtils.resolveFileResource("", "PropertyOverride.groovy");
         final File projectroot = new File(ROOT_DIRECTORY.toFile(), "pom.xml");
 
-        List<Project> projects = new PomIO().parseProject(projectroot);
+        List<Project> projects = new PomIO().parseProject(null, projectroot);
 
         Properties userProperties = new Properties();
         userProperties.setProperty("versionIncrementalSuffix", "rebuild");
@@ -267,7 +267,7 @@ public class BaseScriptTest {
         FileUtils.copyFileToDirectory(pom, tmpFolder);
 
         final File projectroot = new File(tmpFolder, "pom.xml");
-        List<Project> projects = new PomIO().parseProject(projectroot);
+        List<Project> projects = new PomIO().parseProject(null, projectroot);
 
         Properties userProperties = new Properties();
         userProperties.setProperty("versionIncrementalSuffix", "rebuild");

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/groovy/BaseScriptTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/groovy/BaseScriptTest.java
@@ -129,8 +129,8 @@ public class BaseScriptTest {
         PomIO pomIO = new PomIO();
         FileIO fileIO = new FileIO(temporaryFolder.newFolder());
 
-        List<Project> projects = pomIO.parseProject(null, projectroot);
         ManipulationSession ms = TestUtils.createSession(null, projectroot);
+        List<Project> projects = pomIO.parseProject(ms, projectroot);
 
         Project root = projects.stream()
                 .filter(p -> p.getProjectParent() == null)

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/groovy/GroovyFunctionsTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/groovy/GroovyFunctionsTest.java
@@ -65,7 +65,7 @@ public class GroovyFunctionsTest {
                         .getParentFile(),
                 "pom.xml");
         PomIO pomIO = new PomIO();
-        List<Project> projects = pomIO.parseProject(projectroot);
+        List<Project> projects = pomIO.parseProject(null, projectroot);
 
         BaseScriptImplTest impl = new BaseScriptImplTest();
         Properties p = new Properties();
@@ -97,7 +97,7 @@ public class GroovyFunctionsTest {
         final PlexusContainer container = new DefaultPlexusContainer(config);
         final PomIO pomIO = container.lookup(PomIO.class);
         final File projectroot = new File(root, "pom.xml");
-        final List<Project> projects = pomIO.parseProject(projectroot);
+        final List<Project> projects = pomIO.parseProject(null, projectroot);
 
         assertEquals(3, projects.size());
 
@@ -133,7 +133,7 @@ public class GroovyFunctionsTest {
 
         final PlexusContainer container = new DefaultPlexusContainer(config);
         final PomIO pomIO = container.lookup(PomIO.class);
-        final List<Project> projects = pomIO.parseProject(target);
+        final List<Project> projects = pomIO.parseProject(null, target);
 
         assertEquals(1, projects.size());
 

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/impl/InitialGroovyManipulatorTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/impl/InitialGroovyManipulatorTest.java
@@ -73,7 +73,7 @@ public class InitialGroovyManipulatorTest {
 
         PomIO pomIO = container.lookup(PomIO.class);
 
-        List<Project> projects = pomIO.parseProject(projectroot);
+        List<Project> projects = pomIO.parseProject(null, projectroot);
 
         assertThat(projects.size(), equalTo(3));
 
@@ -85,7 +85,7 @@ public class InitialGroovyManipulatorTest {
         smc.getManager().scanAndApply(smc.getSession());
 
         // re-read the projects:
-        projects = pomIO.parseProject(projectroot);
+        projects = pomIO.parseProject(null, projectroot);
         assertThat(projects.size(), equalTo(3));
 
         assertEquals(1, projectForArtifactId(projects, "groovy-project-removal").getModel().getProfiles().size());

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/impl/JSONManipulatorTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/impl/JSONManipulatorTest.java
@@ -66,7 +66,7 @@ public class JSONManipulatorTest {
 
         File target = tf.newFile();
         FileUtils.copyFile(npmFile, target);
-        Project project = new Project(target, TestUtils.getDummyModel());
+        Project project = new Project(null, target, TestUtils.getDummyModel());
 
         jsonManipulator.internalApplyChanges(project, new JSONState.JSONOperation(target.getName(), modifyPath, null));
     }
@@ -77,7 +77,7 @@ public class JSONManipulatorTest {
 
         File target = tf.newFile();
         FileUtils.copyFile(pluginFile, target);
-        Project project = new Project(target, TestUtils.getDummyModel());
+        Project project = new Project(null, target, TestUtils.getDummyModel());
 
         jsonManipulator.internalApplyChanges(
                 project,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/impl/XMLManipulatorTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/impl/XMLManipulatorTest.java
@@ -66,7 +66,7 @@ public class XMLManipulatorTest {
         File target = tf.newFile();
         FileUtils.copyFile(xmlFile, target);
 
-        Project p = new Project(target, TestUtils.getDummyModel());
+        Project p = new Project(null, target, TestUtils.getDummyModel());
 
         xmlManipulator.internalApplyChanges(p, new XMLState.XMLOperation(target.getName(), path, null));
     }
@@ -78,7 +78,7 @@ public class XMLManipulatorTest {
 
         File target = tf.newFile();
         FileUtils.copyFile(xmlFile, target);
-        Project project = new Project(target, TestUtils.getDummyModel());
+        Project project = new Project(null, target, TestUtils.getDummyModel());
 
         xmlManipulator
                 .internalApplyChanges(project, new XMLState.XMLOperation(target.getName(), tomcatPath, replacementGA));

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/PomIOTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/PomIOTest.java
@@ -47,7 +47,7 @@ public class PomIOTest {
         FileUtils.copyFile(resource, projectroot);
 
         PomIO pomIO = new PomIO(TestUtils.createSessionAndManager(new Properties(), projectroot).getSession());
-        List<Project> projects = pomIO.parseProject(projectroot);
+        List<Project> projects = pomIO.parseProject(null, projectroot);
         assertEquals(1, projects.size());
         assertEquals("${one}", projects.get(0).getGroupId());
     }
@@ -62,7 +62,7 @@ public class PomIOTest {
         Properties p = new Properties();
         p.put(PomIO.PARSE_POM_TEMPLATES, "false");
         PomIO pomIO = new PomIO(TestUtils.createSessionAndManager(p, projectroot).getSession());
-        List<Project> projects = pomIO.parseProject(projectroot);
+        List<Project> projects = pomIO.parseProject(null, projectroot);
         assertEquals(0, projects.size());
         assertTrue(systemOutRule.getLog().contains("PomPeek - Could not peek at POM coordinate for"));
     }
@@ -76,7 +76,7 @@ public class PomIOTest {
 
         Properties p = new Properties();
         PomIO pomIO = new PomIO(TestUtils.createSessionAndManager(p, projectroot).getSession());
-        List<Project> projects = pomIO.parseProject(projectroot);
+        List<Project> projects = pomIO.parseProject(null, projectroot);
         assertEquals(1, projects.size());
     }
 }

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/ProfileActivationTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/ProfileActivationTest.java
@@ -41,7 +41,7 @@ public class ProfileActivationTest {
 
     private List<Project> getProject() throws Exception {
         PomIO pomIO = new PomIO();
-        List<Project> projects = pomIO.parseProject(PROJECTROOT);
+        List<Project> projects = pomIO.parseProject(null, PROJECTROOT);
         assertEquals(1, projects.size());
 
         return projects;

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/ProjectComparatorTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/ProjectComparatorTest.java
@@ -73,8 +73,8 @@ public class ProjectComparatorTest {
                         .getParentFile(),
                 "pom.xml");
         PomIO pomIO = new PomIO();
-        List<Project> projectOriginal = pomIO.parseProject(null, projectroot);
-        List<Project> projectNew = pomIO.parseProject(null, projectroot);
+        List<Project> projectOriginal = pomIO.parseProject(session, projectroot);
+        List<Project> projectNew = pomIO.parseProject(session, projectroot);
 
         String result = ProjectComparator.compareProjects(
                 session,
@@ -104,8 +104,8 @@ public class ProjectComparatorTest {
                 "pom.xml");
         PomIO pomIO = new PomIO();
 
-        List<Project> projectOriginal = pomIO.parseProject(null, projectroot);
-        List<Project> projectNew = pomIO.parseProject(null, projectroot);
+        List<Project> projectOriginal = pomIO.parseProject(session, projectroot);
+        List<Project> projectNew = pomIO.parseProject(session, projectroot);
 
         projectNew.forEach(project -> project.getModel().setVersion(project.getVersion() + "-redhat-1"));
         projectNew.forEach(project -> {
@@ -161,8 +161,8 @@ public class ProjectComparatorTest {
                 "pom.xml");
         PomIO pomIO = new PomIO();
 
-        List<Project> projectOriginal = pomIO.parseProject(null, projectroot);
-        List<Project> projectNew = pomIO.parseProject(null, projectroot);
+        List<Project> projectOriginal = pomIO.parseProject(session, projectroot);
+        List<Project> projectNew = pomIO.parseProject(session, projectroot);
 
         projectNew.forEach(project -> project.getModel().setVersion(project.getVersion() + "-redhat-1"));
         projectNew.forEach(project -> {
@@ -215,8 +215,8 @@ public class ProjectComparatorTest {
                 "pom.xml");
         PomIO pomIO = new PomIO();
 
-        List<Project> projectOriginal = pomIO.parseProject(null, projectroot);
-        List<Project> projectNew = pomIO.parseProject(null, projectroot);
+        List<Project> projectOriginal = pomIO.parseProject(session, projectroot);
+        List<Project> projectNew = pomIO.parseProject(session, projectroot);
 
         projectNew.forEach(project -> project.getModel().setVersion(project.getVersion() + "-redhat-1"));
         projectNew.forEach(project -> {

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/ProjectComparatorTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/ProjectComparatorTest.java
@@ -73,8 +73,8 @@ public class ProjectComparatorTest {
                         .getParentFile(),
                 "pom.xml");
         PomIO pomIO = new PomIO();
-        List<Project> projectOriginal = pomIO.parseProject(projectroot);
-        List<Project> projectNew = pomIO.parseProject(projectroot);
+        List<Project> projectOriginal = pomIO.parseProject(null, projectroot);
+        List<Project> projectNew = pomIO.parseProject(null, projectroot);
 
         String result = ProjectComparator.compareProjects(
                 session,
@@ -104,8 +104,8 @@ public class ProjectComparatorTest {
                 "pom.xml");
         PomIO pomIO = new PomIO();
 
-        List<Project> projectOriginal = pomIO.parseProject(projectroot);
-        List<Project> projectNew = pomIO.parseProject(projectroot);
+        List<Project> projectOriginal = pomIO.parseProject(null, projectroot);
+        List<Project> projectNew = pomIO.parseProject(null, projectroot);
 
         projectNew.forEach(project -> project.getModel().setVersion(project.getVersion() + "-redhat-1"));
         projectNew.forEach(project -> {
@@ -161,8 +161,8 @@ public class ProjectComparatorTest {
                 "pom.xml");
         PomIO pomIO = new PomIO();
 
-        List<Project> projectOriginal = pomIO.parseProject(projectroot);
-        List<Project> projectNew = pomIO.parseProject(projectroot);
+        List<Project> projectOriginal = pomIO.parseProject(null, projectroot);
+        List<Project> projectNew = pomIO.parseProject(null, projectroot);
 
         projectNew.forEach(project -> project.getModel().setVersion(project.getVersion() + "-redhat-1"));
         projectNew.forEach(project -> {
@@ -215,8 +215,8 @@ public class ProjectComparatorTest {
                 "pom.xml");
         PomIO pomIO = new PomIO();
 
-        List<Project> projectOriginal = pomIO.parseProject(projectroot);
-        List<Project> projectNew = pomIO.parseProject(projectroot);
+        List<Project> projectOriginal = pomIO.parseProject(null, projectroot);
+        List<Project> projectNew = pomIO.parseProject(null, projectroot);
 
         projectNew.forEach(project -> project.getModel().setVersion(project.getVersion() + "-redhat-1"));
         projectNew.forEach(project -> {

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/ProjectInheritanceTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/ProjectInheritanceTest.java
@@ -53,7 +53,7 @@ public class ProjectInheritanceTest {
         final File projectroot = Paths.get(ROOT_DIRECTORY.toString(), "pom.xml").toFile();
 
         PomIO pomIO = new PomIO();
-        List<Project> projects = pomIO.parseProject(projectroot);
+        List<Project> projects = pomIO.parseProject(null, projectroot);
         for (Project p : projects) {
             if (!p.getPom().equals(projectroot)) {
                 assertEquals(p.getProjectParent().getPom(), projectroot);
@@ -69,7 +69,7 @@ public class ProjectInheritanceTest {
 
         PomIO pomIO = new PomIO();
 
-        List<Project> projects = pomIO.parseProject(projectroot);
+        List<Project> projects = pomIO.parseProject(null, projectroot);
 
         for (int i = 0; i <= 3; i++) {
             if (i == 0) {
@@ -98,7 +98,7 @@ public class ProjectInheritanceTest {
 
         PomIO pomIO = new PomIO();
 
-        List<Project> projects = pomIO.parseProject(projectroot);
+        List<Project> projects = pomIO.parseProject(null, projectroot);
 
         for (Project p : projects) {
             if (p.getKey().toString().equals("io.apiman:apiman-common:1.2.7-SNAPSHOT")) {
@@ -122,7 +122,7 @@ public class ProjectInheritanceTest {
 
         PomIO pomIO = new PomIO();
 
-        List<Project> projects = pomIO.parseProject(relative.toFile());
+        List<Project> projects = pomIO.parseProject(null, relative.toFile());
 
         assertEquals(1, projects.size());
         assertTrue(projects.get(0).isExecutionRoot());
@@ -144,7 +144,7 @@ public class ProjectInheritanceTest {
         Files.createSymbolicLink(dummyPom.toPath(), targetPom.toPath());
 
         PomIO pomIO = new PomIO();
-        List<Project> projects = pomIO.parseProject(dummyPom);
+        List<Project> projects = pomIO.parseProject(null, dummyPom);
 
         assertEquals(1, projects.size());
         assertTrue(projects.get(0).isExecutionRoot());
@@ -158,7 +158,7 @@ public class ProjectInheritanceTest {
 
         PomIO pomIO = new PomIO();
 
-        List<Project> projects = pomIO.parseProject(projectroot);
+        List<Project> projects = pomIO.parseProject(null, projectroot);
 
         for (int i = 0; i <= 3; i++) {
             if (i == 0) {
@@ -186,7 +186,7 @@ public class ProjectInheritanceTest {
                 .toFile();
 
         PomIO pomIO = new PomIO();
-        List<Project> projects = pomIO.parseProject(projectroot);
+        List<Project> projects = pomIO.parseProject(null, projectroot);
         for (Project p : projects) {
             if (p.getPom().equals(projectroot)) {
                 Map<ArtifactRef, Dependency> deps = p.getResolvedManagedDependencies(session);

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/ProjectInheritanceTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/ProjectInheritanceTest.java
@@ -189,17 +189,17 @@ public class ProjectInheritanceTest {
         List<Project> projects = pomIO.parseProject(null, projectroot);
         for (Project p : projects) {
             if (p.getPom().equals(projectroot)) {
-                Map<ArtifactRef, Dependency> deps = p.getResolvedManagedDependencies(session);
+                Map<ArtifactRef, Dependency> deps = p.getResolvedManagedDependencies();
                 for (ArtifactRef a : deps.keySet()) {
                     assertFalse(a.getVersionString().contains("project.version"));
                 }
-                deps = p.getResolvedDependencies(session);
+                deps = p.getResolvedDependencies();
                 assertEquals(1, deps.size());
                 for (ArtifactRef a : deps.keySet()) {
                     assertFalse(a.getVersionString().contains("project.version"));
                 }
                 assertFalse(deps.containsKey(SimpleScopedArtifactRef.parse("org.mockito:mockito-all:jar:*")));
-                deps = p.getAllResolvedDependencies(session);
+                deps = p.getAllResolvedDependencies();
                 assertEquals(3, deps.size());
                 for (ArtifactRef a : deps.keySet()) {
                     assertFalse(a.getVersionString().contains("project.version"));

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/ProjectInheritanceTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/ProjectInheritanceTest.java
@@ -186,7 +186,7 @@ public class ProjectInheritanceTest {
                 .toFile();
 
         PomIO pomIO = new PomIO();
-        List<Project> projects = pomIO.parseProject(null, projectroot);
+        List<Project> projects = pomIO.parseProject(session, projectroot);
         for (Project p : projects) {
             if (p.getPom().equals(projectroot)) {
                 Map<ArtifactRef, Dependency> deps = p.getResolvedManagedDependencies();

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/PropertiesUtilsTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/PropertiesUtilsTest.java
@@ -438,8 +438,8 @@ public class PropertiesUtilsTest {
         ManipulationSession session = createUpdateSession();
         Project pC = new Project(modelChild);
 
-        assertEquals(0, pC.getResolvedPlugins(session).size());
-        assertEquals(0, pC.getResolvedManagedPlugins(session).size());
+        assertEquals(0, pC.getResolvedPlugins().size());
+        assertEquals(0, pC.getResolvedManagedPlugins().size());
     }
 
     @Test

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/PropertiesUtilsTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/PropertiesUtilsTest.java
@@ -152,7 +152,7 @@ public class PropertiesUtilsTest {
     public void testCacheProperty() throws Exception {
         ManipulationSession session = createUpdateSession();
         Map<Project, Map<String, PropertyMapper>> propertyMap = new HashMap<>();
-        Project project = getProject();
+        Project project = getProject(session);
         Plugin dummy = new Plugin();
         dummy.setGroupId("org.dummy");
         dummy.setArtifactId("dummyArtifactId");
@@ -232,8 +232,8 @@ public class PropertiesUtilsTest {
 
     @Test
     public void testUpdateNestedProperties1() throws Exception {
-        Project pP = getProject();
         ManipulationSession session = createUpdateSession();
+        Project pP = getProject(session);
 
         assertSame(
                 updateProperties(session, pP, false, "version.hibernate.core", "5.0.4.Final-redhat-1"),
@@ -251,9 +251,8 @@ public class PropertiesUtilsTest {
 
     @Test
     public void testUpdateNestedProperties2() throws Exception {
-        Project pP = getProject();
-
         ManipulationSession session = createUpdateSession();
+        Project pP = getProject(session);
 
         assertSame(
                 updateProperties(session, pP, false, "version.hibernate.osgi", "5.0.4.Final-redhat-1"),
@@ -294,8 +293,8 @@ public class PropertiesUtilsTest {
 
     @Test
     public void testUpdateNestedProperties4() throws Exception {
-        Project pP = getProject();
         ManipulationSession session = createUpdateSession();
+        Project pP = getProject(session);
 
         assertSame(
                 updateProperties(
@@ -355,8 +354,8 @@ public class PropertiesUtilsTest {
         final Model modelParent = TestUtils.resolveModelResource(RESOURCE_BASE, "infinispan-bom-8.2.0.Final.pom");
         ManipulationSession session = createUpdateSession();
 
-        Project pP = new Project(modelParent);
-        Project pC = new Project(modelChild);
+        Project pP = new Project(session, modelParent.getPomFile(), modelParent);
+        Project pC = new Project(session, modelChild.getPomFile(), modelChild);
         List<Project> al = new ArrayList<>();
         al.add(pC);
         al.add(pP);
@@ -383,9 +382,8 @@ public class PropertiesUtilsTest {
 
     @Test
     public void testUpdateProjectVersionProperty() throws Exception {
-        Project pP = getProject();
-
         ManipulationSession session = createUpdateSession();
+        Project pP = getProject(session);
 
         assertNotSame(
                 updateProperties(session, pP, false, "project.version", "5.0.4.Final-redhat-1"),
@@ -398,9 +396,9 @@ public class PropertiesUtilsTest {
         ManipulationSession session = createUpdateSession();
 
         PomIO pomIO = new PomIO();
-        List<Project> projects = pomIO.parseProject(projectroot);
+        List<Project> projects = pomIO.parseProject(session, projectroot);
 
-        List<Project> newprojects = pomIO.parseProject(projectroot);
+        List<Project> newprojects = pomIO.parseProject(session, projectroot);
 
         WildcardMap<ProjectVersionRef> map = (session.getState(RelocationState.class) == null ? new WildcardMap<>()
                 : session.getState(RelocationState.class).getDependencyRelocations());
@@ -410,9 +408,9 @@ public class PropertiesUtilsTest {
                 result.contains("------------------- project org.infinispan:infinispan-bom" + System.lineSeparator()));
     }
 
-    private Project getProject() throws Exception {
+    private Project getProject(ManipulationSession session) throws Exception {
         final Model modelParent = TestUtils.resolveModelResource(RESOURCE_BASE, "infinispan-bom-8.2.0.Final.pom");
-        return new Project(modelParent);
+        return new Project(session, modelParent.getPomFile(), modelParent);
     }
 
     @SuppressWarnings("deprecation")
@@ -524,7 +522,7 @@ public class PropertiesUtilsTest {
     public void testOriginalTypeChecking() throws Exception {
         ManipulationSession session = createUpdateSession();
         Map<Project, Map<String, PropertyMapper>> propertyMap = new HashMap<>();
-        Project project = getProject();
+        Project project = getProject(session);
 
         try {
             assertFalse(

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/PropertyInterpolatorTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/PropertyInterpolatorTest.java
@@ -86,7 +86,7 @@ public class PropertyInterpolatorTest {
     @Test
     public void testResolveProjectDependencies() throws Exception {
         final Model model = TestUtils.resolveModelResource(RESOURCE_BASE, "infinispan-bom-8.2.0.Final.pom");
-        final Project project = new Project(model);
+        final Project project = new Project(new ManipulationSession(), model.getPomFile(), model);
 
         Map<ArtifactRef, Dependency> deps = project.getResolvedManagedDependencies();
 

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/PropertyInterpolatorTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/PropertyInterpolatorTest.java
@@ -88,7 +88,7 @@ public class PropertyInterpolatorTest {
         final Model model = TestUtils.resolveModelResource(RESOURCE_BASE, "infinispan-bom-8.2.0.Final.pom");
         final Project project = new Project(model);
 
-        Map<ArtifactRef, Dependency> deps = project.getResolvedManagedDependencies(new ManipulationSession());
+        Map<ArtifactRef, Dependency> deps = project.getResolvedManagedDependencies();
 
         assertEquals(66, deps.size());
     }

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/ResolveArtifactTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/ResolveArtifactTest.java
@@ -38,7 +38,7 @@ public class ResolveArtifactTest {
 
         final File projectroot = TestUtils.resolveFileResource(RESOURCE_BASE, "infinispan-bom-8.2.0.Final.pom");
         PomIO pomIO = new PomIO();
-        List<Project> projects = pomIO.parseProject(projectroot);
+        List<Project> projects = pomIO.parseProject(null, projectroot);
 
         Set<ArtifactRef> artifacts = RESTCollector.establishAllDependencies(session, projects, null);
         System.out.println("### artifact count is " + artifacts.size());

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/ResolveArtifactTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/ResolveArtifactTest.java
@@ -38,7 +38,7 @@ public class ResolveArtifactTest {
 
         final File projectroot = TestUtils.resolveFileResource(RESOURCE_BASE, "infinispan-bom-8.2.0.Final.pom");
         PomIO pomIO = new PomIO();
-        List<Project> projects = pomIO.parseProject(null, projectroot);
+        List<Project> projects = pomIO.parseProject(session, projectroot);
 
         Set<ArtifactRef> artifacts = RESTCollector.establishAllDependencies(session, projects, null);
         System.out.println("### artifact count is " + artifacts.size());

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -309,7 +309,7 @@
                   </goals>
                   <localRepositoryPath>${localRepositoryUrlExt}</localRepositoryPath>
                   <mavenHome>${it.maven.home}</mavenHome>
-                  <cloneProjectsTo />
+                  <cloneProjectsTo/>
                   <setupIncludes>
                     <setupInclude>setup/*/pom.xml</setupInclude>
                   </setupIncludes>

--- a/integration-test/src/it/rest-version-manip-with-properties/invoker.properties
+++ b/integration-test/src/it/rest-version-manip-with-properties/invoker.properties
@@ -1,0 +1,18 @@
+#
+# Copyright (C) 2012 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Only validate as the manipulated dependencies won't resolve.
+invoker.goals=validate

--- a/integration-test/src/it/rest-version-manip-with-properties/pom.xml
+++ b/integration-test/src/it/rest-version-manip-with-properties/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2012 Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.jboss.pnc.maven-manipulator.integration-test</groupId>
+  <artifactId>${myArtifactId}</artifactId>
+  <version>${project-version}</version>
+  <packaging>pom</packaging>
+
+  <name>Module to test REST manipulation with properties</name>
+
+  <properties>
+    <myArtifactId>rest-version-manip-with-properties</myArtifactId>
+    <project-version>2.7.2_3-fuse-SNAPSHOT</project-version>
+    <errai-tools>1.1-Final</errai-tools>
+    <httpclient>3.1</httpclient>
+    <httpclient-indirect>${httpclient}</httpclient-indirect>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>commons-lang</groupId>
+        <artifactId>commons-lang</artifactId>
+        <version>1.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.errai</groupId>
+        <artifactId>errai-tools</artifactId>
+        <version>${errai-tools}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.foobar</groupId>
+        <artifactId>my-artifact</artifactId>
+        <version>${exist}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>commons-httpclient</groupId>
+      <artifactId>commons-httpclient</artifactId>
+      <version>${httpclient-indirect}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-common</artifactId>
+      <version>1.1-Final</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>1.0</version>
+      <scope>test</scope>
+      <classifier>sources</classifier>
+    </dependency>
+  </dependencies>
+</project>

--- a/integration-test/src/it/rest-version-manip-with-properties/test.properties
+++ b/integration-test/src/it/rest-version-manip-with-properties/test.properties
@@ -1,0 +1,21 @@
+#
+# Copyright (C) 2012 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+restURL=http://127.0.0.1:8089
+versionIncrementalSuffix=redhat
+overrideTransitive=false
+dependencySource=rest
+versionIncrementalSuffixPadding=0

--- a/integration-test/src/it/rest-version-manip-with-properties/verify.groovy
+++ b/integration-test/src/it/rest-version-manip-with-properties/verify.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2012 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+def pomFile = new File( basedir, 'pom.xml' )
+System.out.println( "Slurping POM: ${pomFile.getAbsolutePath()}" )
+
+def pom = new XmlSlurper().parse( pomFile )
+
+System.out.println( "POM Version: ${pom.version.text()}" )
+assert pom.version.text().equals( "2.7.2.3-fuse-redhat-2" )
+
+v = pom.parent.version.text()
+System.out.println( "POM Version: ${v}" )
+assert v == "\${project-version}"
+
+// Currently the AddSuffixJettyHandler doesn't do OSGi compatibility.
+def dependency = pom.dependencyManagement.dependencies.dependency.find { it.artifactId.text() == "commons-lang" }
+assert dependency != null
+assert dependency.version.text() == "1.0-redhat-1"
+
+dependency = pom.dependencies.dependency.find { it.artifactId.text() == "errai-common" }
+assert dependency != null
+assert dependency.version.text() == "1.1-Final-redhat-1"
+
+def passed = 0
+pom.properties.each {
+    if ( it.text().contains ("3.1-redhat-1") )
+    {
+        passed++
+    }
+    if ( it.text().contains ("2.7.2.3-fuse-redhat-1"))
+    {
+        passed++
+    }
+}
+assert (passed == 2)
+
+def buildLog = new File( basedir, "build.log")
+assert buildLog.getText().contains("Passing 6 GAVs")
+assert !buildLog.getText().contains("Passing 1 Project GAVs into the REST client api [org.jboss.pnc.maven-manipulator.integration-test:\${myArtifactId}:\${project-version}]")
+assert buildLog.getText().contains("Passing 1 Project GAVs into the REST client api [org.jboss.pnc.maven-manipulator.integration-test:rest-version-manip-with-properties:2.7.2_3-fuse-SNAPSHOT]")
+
+File json = new File( basedir, "target/alignmentReport.json")
+assert json.exists()
+assert !json.text.contains('"version" : "${project-version}"')
+assert json.text.contains('"version" : "2.7.2.3-fuse-redhat-1"')
+assert json.text.contains('"artifactId" : "rest-version-manip-with-properties"')

--- a/integration-test/src/it/rest-version-manip-with-properties/verify.groovy
+++ b/integration-test/src/it/rest-version-manip-with-properties/verify.groovy
@@ -18,12 +18,9 @@ System.out.println( "Slurping POM: ${pomFile.getAbsolutePath()}" )
 
 def pom = new XmlSlurper().parse( pomFile )
 
-System.out.println( "POM Version: ${pom.version.text()}" )
-assert pom.version.text().equals( "2.7.2.3-fuse-redhat-2" )
-
-v = pom.parent.version.text()
+v = pom.version.text()
 System.out.println( "POM Version: ${v}" )
-assert v == "\${project-version}"
+assert v == '${project-version}'
 
 // Currently the AddSuffixJettyHandler doesn't do OSGi compatibility.
 def dependency = pom.dependencyManagement.dependencies.dependency.find { it.artifactId.text() == "commons-lang" }
@@ -48,9 +45,9 @@ pom.properties.each {
 assert (passed == 2)
 
 def buildLog = new File( basedir, "build.log")
-assert buildLog.getText().contains("Passing 6 GAVs")
-assert !buildLog.getText().contains("Passing 1 Project GAVs into the REST client api [org.jboss.pnc.maven-manipulator.integration-test:\${myArtifactId}:\${project-version}]")
-assert buildLog.getText().contains("Passing 1 Project GAVs into the REST client api [org.jboss.pnc.maven-manipulator.integration-test:rest-version-manip-with-properties:2.7.2_3-fuse-SNAPSHOT]")
+assert buildLog.getText().contains("Passing 5 GAVs")
+assert !buildLog.getText().contains('Passing 1 Project GAVs into the REST client api [org.jboss.pnc.maven-manipulator.integration-test:${myArtifactId}:${project-version}]')
+assert buildLog.getText().contains("Passing 1 Project GAVs into the REST client api [org.jboss.pnc.maven-manipulator.integration-test:rest-version-manip-with-properties:2.7.2.3-fuse]")
 
 File json = new File( basedir, "target/alignmentReport.json")
 assert json.exists()

--- a/integration-test/src/test/java/org/jboss/pnc/mavenmanipulator/integrationtest/GroovyIntegrationTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/mavenmanipulator/integrationtest/GroovyIntegrationTest.java
@@ -32,7 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class GroovyIntegrationTest {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultCliIntegrationTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(GroovyIntegrationTest.class);
 
     private final StaticResourceHandler handler = new StaticResourceHandler("src/it/setup/depMgmt2/POMModifier.groovy");
 

--- a/integration-test/src/test/java/org/jboss/pnc/mavenmanipulator/integrationtest/RESTIntegrationTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/mavenmanipulator/integrationtest/RESTIntegrationTest.java
@@ -33,7 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RESTIntegrationTest {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultCliIntegrationTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RESTIntegrationTest.class);
 
     private final AddSuffixJettyHandler handler = new AddSuffixJettyHandler("/", null);
 
@@ -187,6 +187,12 @@ public class RESTIntegrationTest {
     @Test
     public void testRESTVersionManipAlignmentDisabled() throws Exception {
         String test = getDefaultTestLocation("rest-version-manip-alignment-disabled");
+        runLikeInvoker(test, mockServer.getUrl());
+    }
+
+    @Test
+    public void testRESTVersionManipWithProperties() throws Exception {
+        String test = getDefaultTestLocation("rest-version-manip-with-properties");
         runLikeInvoker(test, mockServer.getUrl());
     }
 }

--- a/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/PomIO.java
+++ b/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/PomIO.java
@@ -93,10 +93,15 @@ public class PomIO {
         parsePomTemplates = true;
     }
 
-    public List<Project> parseProject(final File pom) throws ManipulationException {
-        final List<PomPeek> peeked = peekAtPomHierarchy(pom);
+    /**
+     * @param session Maven session context (may be null in tests); stored on each parsed {@link Project}
+     * @param pom execution root POM file
+     */
+    public List<Project> parseProject(final MavenSessionHandler session, final File pom)
+            throws ManipulationException {
+        final List<PomPeek> peeked = peekAtPomHierarchy(session, pom);
         try {
-            return readModelsForManipulation(pom.getCanonicalFile(), peeked);
+            return readModelsForManipulation(session, pom.getCanonicalFile(), peeked);
         } catch (IOException e) {
             throw new ManipulationException("Error getting canonical file", e);
         }
@@ -112,7 +117,10 @@ public class PomIO {
      * @return a collection of Projects
      * @throws ManipulationException if an error occurs.
      */
-    private List<Project> readModelsForManipulation(File executionRoot, final List<PomPeek> peeked)
+    private List<Project> readModelsForManipulation(
+            MavenSessionHandler session,
+            File executionRoot,
+            final List<PomPeek> peeked)
             throws ManipulationException {
         final List<Project> projects = new ArrayList<>();
         final HashMap<Project, ProjectVersionRef> projectToParent = new HashMap<>();
@@ -136,7 +144,7 @@ public class PomIO {
                 continue;
             }
 
-            final Project project = new Project(pom, raw);
+            final Project project = new Project(session, pom, raw);
             projectToParent.put(project, peek.getParentKey());
             project.setInheritanceRoot(peek.isInheritanceRoot());
 
@@ -298,7 +306,10 @@ public class PomIO {
         }
     }
 
-    private List<PomPeek> peekAtPomHierarchy(final File topPom)
+    /**
+     * @param session Maven session context (may be null); reserved for callers that need session-aware peeking
+     */
+    private List<PomPeek> peekAtPomHierarchy(final MavenSessionHandler session, final File topPom)
             throws ManipulationException {
         final List<PomPeek> peeked = new ArrayList<>();
 

--- a/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/PomIO.java
+++ b/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/PomIO.java
@@ -93,10 +93,15 @@ public class PomIO {
         parsePomTemplates = true;
     }
 
-    public List<Project> parseProject(final File pom) throws ManipulationException {
+    /**
+     * @param session Maven session context (may be null in tests); stored on each parsed {@link Project}
+     * @param pom execution root POM file
+     */
+    public List<Project> parseProject(final MavenSessionHandler session, final File pom)
+            throws ManipulationException {
         final List<PomPeek> peeked = peekAtPomHierarchy(pom);
         try {
-            return readModelsForManipulation(pom.getCanonicalFile(), peeked);
+            return readModelsForManipulation(session, pom.getCanonicalFile(), peeked);
         } catch (IOException e) {
             throw new ManipulationException("Error getting canonical file", e);
         }
@@ -112,7 +117,10 @@ public class PomIO {
      * @return a collection of Projects
      * @throws ManipulationException if an error occurs.
      */
-    private List<Project> readModelsForManipulation(File executionRoot, final List<PomPeek> peeked)
+    private List<Project> readModelsForManipulation(
+            MavenSessionHandler session,
+            File executionRoot,
+            final List<PomPeek> peeked)
             throws ManipulationException {
         final List<Project> projects = new ArrayList<>();
         final HashMap<Project, ProjectVersionRef> projectToParent = new HashMap<>();
@@ -136,7 +144,7 @@ public class PomIO {
                 continue;
             }
 
-            final Project project = new Project(pom, raw);
+            final Project project = new Project(session, pom, raw);
             projectToParent.put(project, peek.getParentKey());
             project.setInheritanceRoot(peek.isInheritanceRoot());
 

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/PomIOTest.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/PomIOTest.java
@@ -64,7 +64,7 @@ public class PomIOTest {
         File targetFile = folder.newFile("target.xml");
         FileUtils.copyFile(pom, targetFile);
 
-        List<Project> projects = pomIO.parseProject(targetFile);
+        List<Project> projects = pomIO.parseProject(null, targetFile);
 
         assertNull(projects.get(0).getModel().getModelEncoding());
 
@@ -93,7 +93,7 @@ public class PomIOTest {
                 StandardCharsets.UTF_8);
         FileUtils.copyFile(pom, targetFile);
 
-        List<Project> projects = pomIO.parseProject(targetFile);
+        List<Project> projects = pomIO.parseProject(null, targetFile);
         Model model = projects.get(0).getModel();
         model.setGroupId("org.jboss.pnc.maven-manipulator.versioning.test");
         model.setArtifactId("dospom");
@@ -101,7 +101,7 @@ public class PomIOTest {
         model.setPackaging("pom");
         model.setModelVersion("4.0.0");
 
-        Project p = new Project(targetFile, model);
+        Project p = new Project(null, targetFile, model);
         HashSet<Project> changed = new HashSet<>();
         changed.add(p);
         pomIO.rewritePOMs(changed);
@@ -121,7 +121,7 @@ public class PomIOTest {
         File targetFile = folder.newFile("target.xml");
         FileUtils.copyFile(pom, targetFile);
 
-        List<Project> projects = pomIO.parseProject(targetFile);
+        List<Project> projects = pomIO.parseProject(null, targetFile);
         Project p = projects.get(0);
         p.getModel().getRepositories().clear();
 
@@ -130,7 +130,7 @@ public class PomIOTest {
 
         pomIO.rewritePOMs(changed);
 
-        p = pomIO.parseProject(targetFile).get(0);
+        p = pomIO.parseProject(null, targetFile).get(0);
 
         assertEquals(0, p.getModel().getRepositories().size());
     }
@@ -177,7 +177,7 @@ public class PomIOTest {
         File targetFile = folder.newFile("target.xml");
         FileUtils.copyFile(pom, targetFile);
 
-        Project project = pomIO.parseProject(targetFile).get(0);
+        Project project = pomIO.parseProject(null, targetFile).get(0);
         project.setExecutionRoot();
 
         HashSet<Project> changed = new HashSet<>();

--- a/pom.xml
+++ b/pom.xml
@@ -95,8 +95,8 @@
     <mavenReleaseVersion>3.3.1</mavenReleaseVersion>
 
     <jacksonVersion>2.20.0</jacksonVersion>
-    <argLine />
-    <surefireSecurityManager />
+    <argLine/>
+    <surefireSecurityManager/>
   </properties>
 
   <dependencyManagement>
@@ -606,10 +606,10 @@
             </additionalClasspathElements>
             <!-- ensure we don't inherit a byteman jar from any env settings -->
             <environmentVariables>
-              <BYTEMAN_HOME />
+              <BYTEMAN_HOME/>
             </environmentVariables>
             <systemPropertyVariables>
-              <org.jboss.byteman.home />
+              <org.jboss.byteman.home/>
               <org.slf4j.simpleLogger.defaultLogLevel>DEBUG</org.slf4j.simpleLogger.defaultLogLevel>
             </systemPropertyVariables>
           </configuration>
@@ -800,7 +800,7 @@
             </sortPom>
           </pom>
           <java>
-            <removeUnusedImports />
+            <removeUnusedImports/>
             <importOrder>
               <file>java-import-order.txt</file>
             </importOrder>

--- a/pom.xml
+++ b/pom.xml
@@ -95,8 +95,8 @@
     <mavenReleaseVersion>3.3.1</mavenReleaseVersion>
 
     <jacksonVersion>2.21.2</jacksonVersion>
-    <argLine />
-    <surefireSecurityManager />
+    <argLine/>
+    <surefireSecurityManager/>
   </properties>
 
   <dependencyManagement>
@@ -606,10 +606,10 @@
             </additionalClasspathElements>
             <!-- ensure we don't inherit a byteman jar from any env settings -->
             <environmentVariables>
-              <BYTEMAN_HOME />
+              <BYTEMAN_HOME/>
             </environmentVariables>
             <systemPropertyVariables>
-              <org.jboss.byteman.home />
+              <org.jboss.byteman.home/>
               <org.slf4j.simpleLogger.defaultLogLevel>DEBUG</org.slf4j.simpleLogger.defaultLogLevel>
             </systemPropertyVariables>
           </configuration>
@@ -800,7 +800,7 @@
             </sortPom>
           </pom>
           <java>
-            <removeUnusedImports />
+            <removeUnusedImports/>
             <importOrder>
               <file>java-import-order.txt</file>
             </importOrder>


### PR DESCRIPTION
This refactors the Project.java to always have a MavenSession ; this simplifies many of the callers as they don't need to pass in a session (e.g. `currentProject.getResolved*`) and the session can be used then to return a fully resolved artifactId:groupId:version. This is critical when writing the json report or collecting versions to send to the REST API.