### PR TITLE
NCL-9664 Move to using jboss-parent

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -41,17 +41,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        maven-version: [3.3.9, 3.5.4, 3.6.3, 3.8.7, 3.9.0, 3.9.8]
+        maven-version: [3.6.3, 3.8.7, 3.9.0, 3.9.8]
         java-version: ['11']
-        # Use include to add a specific Maven/JDK combination
+        build-command: ['mvn -B -V clean install -Prun-its']
+        # Use include to add a specific Maven/JDK/Build-command combination
         include:
+          - maven-version: 3.3.9
+            java-version: '11'
+            build-command: "mvn -B -V clean install -Prun-its -Pearly-maven"
+          - maven-version: 3.5.4
+            java-version: '11'
+            build-command: "mvn -B -V clean install -Prun-its -Pearly-maven"
           - maven-version: 3.9.11
             java-version: '17'
+            build-command: "mvn -B -V clean install -Prun-its"
           - maven-version: 3.9.15
             java-version: '17'
+            build-command: "mvn -B -V clean install -Prun-its"
     uses: project-ncl/shared-github-actions/.github/workflows/maven-ci.yml@ef31e53140344cac0421b7211cc0940182409106 # v0.0.16
     with:
-      build_command: "mvn -B -V clean install -Prun-its"
+      build_command: ${{ matrix.build-command }}
       java_version: ${{ matrix.java-version }}
       maven_version: ${{ matrix.maven-version }}
   codecov:

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -329,30 +329,11 @@ libraries without somehow gaining access to that `SNAPSHOT` BOM.
 #### Check for Improperly Formatted License Headers
 
 Each source file, along with `pom.xml` and test resource files, should have a header comment that reflects the license
-of the project. We're using the [license-maven-plugin](https://mycila.mathieu.photography/license-maven-plugin/) for
-this purpose. It reformats license headers when you use the formatting profile (`-Pformatting`) and verifies their
+of the project. We're using the [license-maven-plugin](https://mathieu.carbou.me/license-maven-plugin/) for
+this purpose. It reformats license headers when you run `mvn com.mycila:license-maven-plugin:check` and verifies their
 presence and correctness during the project release as part of the release build profile. If any of the license
 headers are missing or incorrect, the verification step will fail the build leaving you with a release to rollback
-before you can correct the problem and try again.
-
-So, before you try to run the actual release, perform the following steps:
-
-```
-#!/bin/bash
-
-# We don't need tests, but may need module dependency assemblies, etc.
-mvn -Pformatting clean install -DskipTests=true
-
-# Check whether any files were updated
-git status | grep 'modified:'
-changed=$?
-
-# Only necessary if files changed
-if [ $changed != 0 ]; then
-    git add .
-    git commit -am "Fix license headers"
-fi
-```
+before you can correct the problem and try again. To correct the format run `mvn com.mycila:license-maven-plugin:format`.
 
 ### Run the Release
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -138,7 +138,7 @@ at improving reproducibility and reducing the confusion of a variable build envi
 Integration/functional tests are not run in the default build. To run them, you can use one of the following profiles:
 
 * `run-its`
-* `release` (this is used when we release projects)
+* `central-release` (this is used when we release projects; includes license header checking and integration tests)
 
 Dependency versions are kept in the root POM for the project inside the `dependencyManagement` section (*not* in the
 normal `dependencies` section). Declare the most commonly used scope for the dependency inside the project if it's not
@@ -357,12 +357,12 @@ fi
 ### Run the Release
 
 ```
-mvn clean release:prepare release:perform -Prelease
+mvn clean release:prepare release:perform -Pcentral-release
 ```
 
 Or, if you have a GPG profile in your `$HOME/.m2/settings.xml`:
 ```
-mvn clean release:prepare release:perform -Prelease -Pgpg
+mvn clean release:prepare release:perform -Pcentral-release -Pgpg
 ```
 
 **Note**: Due to quirks with the Maven release plugin, to avoid running the integration tests for both `prepare` and `perform`

--- a/annotation/pom.xml
+++ b/annotation/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/annotation/src/main/java/org/jboss/pnc/mavenmanipulator/annotation/ConfigValue.java
+++ b/annotation/src/main/java/org/jboss/pnc/mavenmanipulator/annotation/ConfigValue.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/annotation/src/main/java/org/jboss/pnc/mavenmanipulator/annotation/ConfigValueProcessor.java
+++ b/annotation/src/main/java/org/jboss/pnc/mavenmanipulator/annotation/ConfigValueProcessor.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/cli/src/main/assembly/bin.xml
+++ b/cli/src/main/assembly/bin.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/cli/src/main/java/org/jboss/pnc/mavenmanipulator/cli/Cli.java
+++ b/cli/src/main/java/org/jboss/pnc/mavenmanipulator/cli/Cli.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/cli/src/main/java/org/jboss/pnc/mavenmanipulator/cli/ManifestVersionProvider.java
+++ b/cli/src/main/java/org/jboss/pnc/mavenmanipulator/cli/ManifestVersionProvider.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.jboss.pnc.mavenmanipulator.cli;
 
 import org.jboss.pnc.mavenmanipulator.common.exception.ManipulationException;

--- a/cli/src/main/resources/logback.xml
+++ b/cli/src/main/resources/logback.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/cli/src/test/java/org/jboss/pnc/mavenmanipulator/cli/CliLoggingTest.java
+++ b/cli/src/test/java/org/jboss/pnc/mavenmanipulator/cli/CliLoggingTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/cli/src/test/java/org/jboss/pnc/mavenmanipulator/cli/CliTest.java
+++ b/cli/src/test/java/org/jboss/pnc/mavenmanipulator/cli/CliTest.java
@@ -325,7 +325,7 @@ public class CliTest {
                 .replaceAll("org.jboss.pnc.maven-manipulator:pom-manipulation-.*\\n", "");
         System.out.println(cliOutput);
 
-        assertTrue(cliOutput.contains("Found 86"));
+        assertTrue(cliOutput.contains("Found 87"));
         assertTrue(
                 cliOutput.matches(
                         "(?s).*"
@@ -340,7 +340,7 @@ public class CliTest {
                                 + "com.jayway.jsonpath:json-path:2.[.\\d+]+\\s+                                    jar                                     compile             \n"
                                 + "com.konghq:unirest-java:3.[.\\d+]+\\s+                                          jar                                     compile             \n"
                                 + "com.konghq:unirest-objectmapper-jackson:3.[.\\d+]+\\s+                          jar                                     compile             \n"
-                                + "com.redhat.rcm:redhat-releng-tools:12\\s+                                       pom                                     compile             \n"
+                                + "com.mycila:license-maven-plugin:[.\\d+]+\\s+                                    maven-plugin                                                \n"
                                 + "com.redhat.resilience.otel:opentelemetry-ext-cli-java:1.[.\\d+]+\\s+            jar                                     compile             \n"
                                 + "com.soebes.maven.plugins:iterator-maven-plugin:0.[.\\d+]+\\s+                   maven-plugin                                                \n"
                                 + "com.squareup:javapoet:1.[.\\d+]+\\s+                                            jar                                     compile             \n"
@@ -392,6 +392,7 @@ public class CliTest {
                                 + "org.goots.hiderdoclet:doclet:1.1                                                jar                                     provided            \n"
                                 + "org.hamcrest:hamcrest-all:1.3                                                   jar                                     test                \n"
                                 + "org.jacoco:jacoco-maven-plugin:0.8[.\\d+]+\\s+                                  maven-plugin                                                \n"
+                                + "org.jboss:jboss-parent:\\d+\\s+                                                 pom                                     compile             \n"
                                 + "org.jboss.byteman:byteman-bmunit:4[.\\d+]+\\s+                                  jar                                     test                \n"
                                 + "org.jboss.da:reports-model:2.[.\\d+]+\\s+                                       jar                                     compile             \n"
                                 + "org.jdom:jdom2:2.[.\\d+]+\\s+                                                   jar                                     compile             \n"

--- a/cli/src/test/java/org/jboss/pnc/mavenmanipulator/cli/CliTest.java
+++ b/cli/src/test/java/org/jboss/pnc/mavenmanipulator/cli/CliTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/cli/src/test/java/org/jboss/pnc/mavenmanipulator/cli/CliTest.java
+++ b/cli/src/test/java/org/jboss/pnc/mavenmanipulator/cli/CliTest.java
@@ -463,6 +463,10 @@ public class CliTest {
         assertTrue(systemOutRule.getLog().contains("Running manipulator"));
 
         systemOutRule.clearLog();
+        File marker = new File(folder, "target/pom-manip-ext-marker.txt");
+        if (marker.exists()) {
+            marker.delete();
+        }
 
         c = new Cli();
         c.run(

--- a/cli/src/test/resources/settings-test.xml
+++ b/cli/src/test/resources/settings-test.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/cli/src/test/resources/test.pom
+++ b/cli/src/test/resources/test.pom
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/common-lite/pom.xml
+++ b/common-lite/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/Version.java
+++ b/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/Version.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/exception/ExceptionHelper.java
+++ b/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/exception/ExceptionHelper.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.jboss.pnc.mavenmanipulator.common.exception;
 
 /**

--- a/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/exception/ManipulationException.java
+++ b/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/exception/ManipulationException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/exception/ManipulationUncheckedException.java
+++ b/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/exception/ManipulationUncheckedException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/json/DependencyAnalyserResult.java
+++ b/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/json/DependencyAnalyserResult.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/json/ErrorMessage.java
+++ b/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/json/ErrorMessage.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/json/GAV.java
+++ b/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/json/GAV.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/json/ManagedDependenciesItem.java
+++ b/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/json/ManagedDependenciesItem.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/json/ManagedPluginsItem.java
+++ b/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/json/ManagedPluginsItem.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/json/ModulesItem.java
+++ b/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/json/ModulesItem.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/json/PME.java
+++ b/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/json/PME.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/json/ProfileItem.java
+++ b/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/json/ProfileItem.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/json/PropertiesItem.java
+++ b/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/json/PropertiesItem.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/json/package-info.java
+++ b/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/json/package-info.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * This package contains the JSON POJOs objects that PME uses.
  *

--- a/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/JSONUtils.java
+++ b/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/JSONUtils.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/ManifestUtils.java
+++ b/common-lite/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/ManifestUtils.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common-lite/src/test/java/org/jboss/pnc/mavenmanipulator/common/VersionTest.java
+++ b/common-lite/src/test/java/org/jboss/pnc/mavenmanipulator/common/VersionTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common-lite/src/test/java/org/jboss/pnc/mavenmanipulator/common/util/JSONUtilsTest.java
+++ b/common-lite/src/test/java/org/jboss/pnc/mavenmanipulator/common/util/JSONUtilsTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/jdom/IndentationCounter.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/jdom/IndentationCounter.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.jboss.pnc.mavenmanipulator.common.jdom;
 
 /**

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/jdom/JDOMModelConverter.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/jdom/JDOMModelConverter.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.jboss.pnc.mavenmanipulator.common.jdom;
 
 import java.util.Collection;

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/jdom/JDOMSettingsConverter.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/jdom/JDOMSettingsConverter.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.jboss.pnc.mavenmanipulator.common.jdom;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/jdom/Utils.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/jdom/Utils.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.jboss.pnc.mavenmanipulator.common.jdom;
 
 import java.util.ArrayList;

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/model/ArtifactPluginWrapper.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/model/ArtifactPluginWrapper.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/model/Project.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/model/Project.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/model/SimpleScopedArtifactRef.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/model/SimpleScopedArtifactRef.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/model/YamlFile.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/model/YamlFile.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/session/MavenSessionHandler.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/session/MavenSessionHandler.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/GAVUtils.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/GAVUtils.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/LineSeparator.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/LineSeparator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.jboss.pnc.mavenmanipulator.common.util;
 
 /**

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/ListUtils.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/ListUtils.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/PMEObjectMapper.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/PMEObjectMapper.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/ProfileUtils.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/ProfileUtils.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/ProjectComparator.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/ProjectComparator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/PropertyInterpolator.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/PropertyInterpolator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/PropertyResolver.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/PropertyResolver.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/WildcardMap.java
+++ b/common/src/main/java/org/jboss/pnc/mavenmanipulator/common/util/WildcardMap.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/src/test/java/org/jboss/pnc/mavenmanipulator/common/model/ProjectTest.java
+++ b/common/src/test/java/org/jboss/pnc/mavenmanipulator/common/model/ProjectTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/src/test/java/org/jboss/pnc/mavenmanipulator/common/model/SetAndSimpleScopeTest.java
+++ b/common/src/test/java/org/jboss/pnc/mavenmanipulator/common/model/SetAndSimpleScopeTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/src/test/java/org/jboss/pnc/mavenmanipulator/common/util/ManifestUtilsTest.java
+++ b/common/src/test/java/org/jboss/pnc/mavenmanipulator/common/util/ManifestUtilsTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/src/test/java/org/jboss/pnc/mavenmanipulator/common/util/WildcardMapTest.java
+++ b/common/src/test/java/org/jboss/pnc/mavenmanipulator/common/util/WildcardMapTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/commonjava/maven/ext/core/groovy/BaseScript.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/groovy/BaseScript.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/commonjava/maven/ext/core/groovy/GMEBaseScript.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/groovy/GMEBaseScript.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/commonjava/maven/ext/core/groovy/GradleBaseScript.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/groovy/GradleBaseScript.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/commonjava/maven/ext/core/groovy/InvocationPoint.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/groovy/InvocationPoint.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/commonjava/maven/ext/core/groovy/InvocationStage.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/groovy/InvocationStage.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/commonjava/maven/ext/core/groovy/PMEBaseScript.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/groovy/PMEBaseScript.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/commonjava/maven/ext/core/groovy/SBTBaseScript.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/groovy/SBTBaseScript.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/commonjava/maven/ext/core/groovy/SMEGBaseScript.java
+++ b/core/src/main/java/org/commonjava/maven/ext/core/groovy/SMEGBaseScript.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/ManipulationManager.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/ManipulationManager.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/ManipulationSession.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/ManipulationSession.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/ASTTransformer.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/ASTTransformer.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.jboss.pnc.mavenmanipulator.core.groovy;
 
 import static org.apache.groovy.ast.tools.ClassNodeUtils.addGeneratedMethod;

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/BaseScript.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/BaseScript.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/BaseScriptUtils.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/BaseScriptUtils.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/CommonBaseScript.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/CommonBaseScript.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/GMEBaseScript.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/GMEBaseScript.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/GradleBaseScript.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/GradleBaseScript.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/InvocationPoint.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/InvocationPoint.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/InvocationStage.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/InvocationStage.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/MavenBaseScript.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/MavenBaseScript.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/PMEBaseScript.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/PMEBaseScript.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/SBTBaseScript.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/SBTBaseScript.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/SMEGBaseScript.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/groovy/SMEGBaseScript.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/BOMBuilderManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/BOMBuilderManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/BaseGroovyManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/BaseGroovyManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/BasePluginRemovalManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/BasePluginRemovalManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/CentralAndNexusMavenPluginRemovalManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/CentralAndNexusMavenPluginRemovalManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/CommonManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/CommonManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/DependencyInjectionManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/DependencyInjectionManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/DependencyManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/DependencyManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/DependencyRemovalManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/DependencyRemovalManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/DistributionEnforcingManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/DistributionEnforcingManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/FinalGroovyManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/FinalGroovyManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/InitialGroovyManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/InitialGroovyManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/JSONManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/JSONManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/Manipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/Manipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/ParentInjectionManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/ParentInjectionManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/PluginInjectingManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/PluginInjectingManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/PluginManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/PluginManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/PluginRemovalManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/PluginRemovalManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/PreparseGroovyManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/PreparseGroovyManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/ProfileInjectionManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/ProfileInjectionManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/ProfileRemovalManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/ProfileRemovalManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/ProjectVersionEnforcingManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/ProjectVersionEnforcingManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/ProjectVersioningManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/ProjectVersioningManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/PropertyManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/PropertyManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/RESTBOMCollector.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/RESTBOMCollector.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/RESTCollector.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/RESTCollector.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/RangeResolver.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/RangeResolver.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/RelocationManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/RelocationManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/RepoAndReportingRemovalManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/RepoAndReportingRemovalManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/RepositoryInjectionManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/RepositoryInjectionManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/SuffixManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/SuffixManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/Version.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/Version.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.jboss.pnc.mavenmanipulator.core.impl;
 
 /**

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/VersionCalculator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/VersionCalculator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/XMLManipulator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/impl/XMLManipulator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/BOMInjectingState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/BOMInjectingState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/CentralAndNexusMavenPluginRemovalState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/CentralAndNexusMavenPluginRemovalState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/CommonState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/CommonState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/DependencyInjectionState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/DependencyInjectionState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/DependencyRemovalState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/DependencyRemovalState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/DependencyState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/DependencyState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/DistributionEnforcingState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/DistributionEnforcingState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/EnforcingMode.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/EnforcingMode.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/GroovyState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/GroovyState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/JSONState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/JSONState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/ParentInjectionState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/ParentInjectionState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/PluginInjectingState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/PluginInjectingState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/PluginRemovalState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/PluginRemovalState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/PluginState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/PluginState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/ProfileInjectionState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/ProfileInjectionState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/ProfileRemovalState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/ProfileRemovalState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/ProjectVersionEnforcingState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/ProjectVersionEnforcingState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/PropertyState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/PropertyState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/RESTState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/RESTState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/RangeResolverState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/RangeResolverState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/RelocationState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/RelocationState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/RepoReportingState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/RepoReportingState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/RepositoryInjectionState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/RepositoryInjectionState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/State.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/State.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/SuffixState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/SuffixState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/VersioningState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/VersioningState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/XMLState.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/state/XMLState.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/util/DependencyPluginUtils.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/util/DependencyPluginUtils.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/util/DependencyPluginWrapper.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/util/DependencyPluginWrapper.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/util/IdUtils.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/util/IdUtils.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/util/ManipulatorPriorityComparator.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/util/ManipulatorPriorityComparator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/util/PluginReference.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/util/PluginReference.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.jboss.pnc.mavenmanipulator.core.util;
 
 import org.apache.maven.model.ConfigurationContainer;

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/util/PropertiesUtils.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/util/PropertiesUtils.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/util/PropertyMapper.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/util/PropertyMapper.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/util/RefParseUtils.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/util/RefParseUtils.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/ManipulationManagerTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/ManipulationManagerTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/fixture/PlexusTestRunner.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/fixture/PlexusTestRunner.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/fixture/StubTransport.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/fixture/StubTransport.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/fixture/TestUtils.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/fixture/TestUtils.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/fixture/TestWithPlexusRunner.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/fixture/TestWithPlexusRunner.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/groovy/BaseScriptTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/groovy/BaseScriptTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/groovy/GroovyFunctionsTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/groovy/GroovyFunctionsTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/impl/DependencyInjectionManipulatorTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/impl/DependencyInjectionManipulatorTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/impl/DistributionEnforcingManipulatorTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/impl/DistributionEnforcingManipulatorTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/impl/InitialGroovyManipulatorTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/impl/InitialGroovyManipulatorTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/impl/JSONManipulatorTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/impl/JSONManipulatorTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/impl/ProjectVersionManipulatorTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/impl/ProjectVersionManipulatorTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/impl/VersionRangeTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/impl/VersionRangeTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/impl/VersioningCalculatorTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/impl/VersioningCalculatorTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/impl/XMLManipulatorTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/impl/XMLManipulatorTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/io/ModelResolverTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/io/ModelResolverTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/io/ResolverTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/io/ResolverTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/state/CommonStateTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/state/CommonStateTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/state/EnforcingModeTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/state/EnforcingModeTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/state/RelocationStateTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/state/RelocationStateTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/state/SuffixStateTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/state/SuffixStateTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/state/VersioningStateAlternativesTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/state/VersioningStateAlternativesTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/state/VersioningStateTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/state/VersioningStateTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/CheckStrictValueAlternativesTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/CheckStrictValueAlternativesTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/CheckStrictValueTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/CheckStrictValueTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/IdUtilsTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/IdUtilsTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.jboss.pnc.mavenmanipulator.core.util;
 
 import static org.junit.Assert.assertEquals;

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/PomIOTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/PomIOTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/ProfileActivationTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/ProfileActivationTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/ProjectComparatorTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/ProjectComparatorTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/ProjectInheritanceTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/ProjectInheritanceTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/PropertiesUtilsTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/PropertiesUtilsTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/PropertyInterpolatorTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/PropertyInterpolatorTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/ResolveArtifactTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/util/ResolveArtifactTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/resources/GroovyExceptions.groovy
+++ b/core/src/test/resources/GroovyExceptions.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/resources/PropertyOverride.groovy
+++ b/core/src/test/resources/PropertyOverride.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/resources/enforce-skip/exec-detect-skip.pom
+++ b/core/src/test/resources/enforce-skip/exec-detect-skip.pom
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/resources/enforce-skip/profile-deploy-skip.pom
+++ b/core/src/test/resources/enforce-skip/profile-deploy-skip.pom
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/resources/enforce-skip/simple-deploy-skip.pom
+++ b/core/src/test/resources/enforce-skip/simple-deploy-skip.pom
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/resources/enforce-skip/simple-detect-skip.pom
+++ b/core/src/test/resources/enforce-skip/simple-detect-skip.pom
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/resources/groovy-project-removal/legacy-manipulation.groovy
+++ b/core/src/test/resources/groovy-project-removal/legacy-manipulation.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/resources/groovy-project-removal/manipulation.groovy
+++ b/core/src/test/resources/groovy-project-removal/manipulation.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/resources/groovy-project-removal/moduleA/pom.xml
+++ b/core/src/test/resources/groovy-project-removal/moduleA/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/resources/groovy-project-removal/moduleB/pom.xml
+++ b/core/src/test/resources/groovy-project-removal/moduleB/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/resources/groovy-project-removal/pom.xml
+++ b/core/src/test/resources/groovy-project-removal/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/resources/pom-quarkus.xml
+++ b/core/src/test/resources/pom-quarkus.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/resources/pom-variables.xml
+++ b/core/src/test/resources/pom-variables.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/resources/profile.pom
+++ b/core/src/test/resources/profile.pom
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/resources/properties/infinispan-bom-8.2.0.Final.pom
+++ b/core/src/test/resources/properties/infinispan-bom-8.2.0.Final.pom
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/resources/properties/inherited-properties.pom
+++ b/core/src/test/resources/properties/inherited-properties.pom
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/core/src/test/resources/properties/project-1.4.9.pom
+++ b/core/src/test/resources/properties/project-1.4.9.pom
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/coverage-reporting/pom.xml
+++ b/coverage-reporting/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/ext/src/main/java/org/jboss/pnc/mavenmanipulator/ext/ManipulatingEventSpy.java
+++ b/ext/src/main/java/org/jboss/pnc/mavenmanipulator/ext/ManipulatingEventSpy.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ext/src/main/java/org/jboss/pnc/mavenmanipulator/ext/ManipulatingLifeCycleParticipant.java
+++ b/ext/src/main/java/org/jboss/pnc/mavenmanipulator/ext/ManipulatingLifeCycleParticipant.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-child-inherit/child/pom.xml
+++ b/integration-test/src/it/ai-parent-child-inherit/child/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-child-inherit/child/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/ai-parent-child-inherit/child/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-child-inherit/child/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/ai-parent-child-inherit/child/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-child-inherit/invoker.properties
+++ b/integration-test/src/it/ai-parent-child-inherit/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-child-inherit/pom.xml
+++ b/integration-test/src/it/ai-parent-child-inherit/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-child-inherit/test.properties
+++ b/integration-test/src/it/ai-parent-child-inherit/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-child-inherit/verify.groovy
+++ b/integration-test/src/it/ai-parent-child-inherit/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-children-interdep-expr/child1/pom.xml
+++ b/integration-test/src/it/ai-parent-children-interdep-expr/child1/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-children-interdep-expr/child1/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/ai-parent-children-interdep-expr/child1/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-children-interdep-expr/child1/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/ai-parent-children-interdep-expr/child1/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-children-interdep-expr/child2/pom.xml
+++ b/integration-test/src/it/ai-parent-children-interdep-expr/child2/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-children-interdep-expr/child2/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/ai-parent-children-interdep-expr/child2/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-children-interdep-expr/child2/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/ai-parent-children-interdep-expr/child2/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-children-interdep-expr/invoker.properties
+++ b/integration-test/src/it/ai-parent-children-interdep-expr/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-children-interdep-expr/pom.xml
+++ b/integration-test/src/it/ai-parent-children-interdep-expr/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-children-interdep-expr/test.properties
+++ b/integration-test/src/it/ai-parent-children-interdep-expr/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-children-interdep-expr/verify.groovy
+++ b/integration-test/src/it/ai-parent-children-interdep-expr/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-children-interdep/child1/pom.xml
+++ b/integration-test/src/it/ai-parent-children-interdep/child1/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-children-interdep/child1/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/ai-parent-children-interdep/child1/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-children-interdep/child1/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/ai-parent-children-interdep/child1/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-children-interdep/child2/pom.xml
+++ b/integration-test/src/it/ai-parent-children-interdep/child2/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-children-interdep/child2/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/ai-parent-children-interdep/child2/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-children-interdep/child2/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/ai-parent-children-interdep/child2/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-children-interdep/invoker.properties
+++ b/integration-test/src/it/ai-parent-children-interdep/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-children-interdep/pom.xml
+++ b/integration-test/src/it/ai-parent-children-interdep/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-children-interdep/test.properties
+++ b/integration-test/src/it/ai-parent-children-interdep/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-parent-children-interdep/verify.groovy
+++ b/integration-test/src/it/ai-parent-children-interdep/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-alphanumeric/invoker.properties
+++ b/integration-test/src/it/ai-simple-alphanumeric/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-alphanumeric/pom.xml
+++ b/integration-test/src/it/ai-simple-alphanumeric/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-alphanumeric/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/ai-simple-alphanumeric/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-alphanumeric/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/ai-simple-alphanumeric/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-alphanumeric/test.properties
+++ b/integration-test/src/it/ai-simple-alphanumeric/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-alphanumeric/verify.groovy
+++ b/integration-test/src/it/ai-simple-alphanumeric/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric-double-invocation/invoker.properties
+++ b/integration-test/src/it/ai-simple-numeric-double-invocation/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric-double-invocation/pom.xml
+++ b/integration-test/src/it/ai-simple-numeric-double-invocation/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric-double-invocation/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/ai-simple-numeric-double-invocation/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric-double-invocation/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/ai-simple-numeric-double-invocation/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric-double-invocation/test.properties
+++ b/integration-test/src/it/ai-simple-numeric-double-invocation/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric-double-invocation/verify.groovy
+++ b/integration-test/src/it/ai-simple-numeric-double-invocation/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric-external-parent/invoker.properties
+++ b/integration-test/src/it/ai-simple-numeric-external-parent/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric-external-parent/pom.xml
+++ b/integration-test/src/it/ai-simple-numeric-external-parent/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric-external-parent/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/ai-simple-numeric-external-parent/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric-external-parent/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/ai-simple-numeric-external-parent/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric-external-parent/test.properties
+++ b/integration-test/src/it/ai-simple-numeric-external-parent/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric-external-parent/verify.groovy
+++ b/integration-test/src/it/ai-simple-numeric-external-parent/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric-padding/invoker.properties
+++ b/integration-test/src/it/ai-simple-numeric-padding/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric-padding/pom.xml
+++ b/integration-test/src/it/ai-simple-numeric-padding/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric-padding/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/ai-simple-numeric-padding/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric-padding/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/ai-simple-numeric-padding/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric-padding/test.properties
+++ b/integration-test/src/it/ai-simple-numeric-padding/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric-padding/verify.groovy
+++ b/integration-test/src/it/ai-simple-numeric-padding/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric-preserved-padding/invoker.properties
+++ b/integration-test/src/it/ai-simple-numeric-preserved-padding/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric-preserved-padding/pom.xml
+++ b/integration-test/src/it/ai-simple-numeric-preserved-padding/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric-preserved-padding/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/ai-simple-numeric-preserved-padding/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric-preserved-padding/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/ai-simple-numeric-preserved-padding/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric-preserved-padding/test.properties
+++ b/integration-test/src/it/ai-simple-numeric-preserved-padding/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric-preserved-padding/verify.groovy
+++ b/integration-test/src/it/ai-simple-numeric-preserved-padding/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric/invoker.properties
+++ b/integration-test/src/it/ai-simple-numeric/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric/pom.xml
+++ b/integration-test/src/it/ai-simple-numeric/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/ai-simple-numeric/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/ai-simple-numeric/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric/test.properties
+++ b/integration-test/src/it/ai-simple-numeric/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/ai-simple-numeric/verify.groovy
+++ b/integration-test/src/it/ai-simple-numeric/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/alignment-activation/pom.xml
+++ b/integration-test/src/it/alignment-activation/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/alignment-activation/test.properties
+++ b/integration-test/src/it/alignment-activation/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/alignment-activation/verify.groovy
+++ b/integration-test/src/it/alignment-activation/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/basic-property-override/pom.xml
+++ b/integration-test/src/it/basic-property-override/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/basic-property-override/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/basic-property-override/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/basic-property-override/test.properties
+++ b/integration-test/src/it/basic-property-override/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/cdata/invoker.properties
+++ b/integration-test/src/it/cdata/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/cdata/pom.xml
+++ b/integration-test/src/it/cdata/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/cdata/test.properties
+++ b/integration-test/src/it/cdata/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/cdata/verify.groovy
+++ b/integration-test/src/it/cdata/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/central-publishing-maven-plugin-removal/invoker.properties
+++ b/integration-test/src/it/central-publishing-maven-plugin-removal/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/central-publishing-maven-plugin-removal/pom.xml
+++ b/integration-test/src/it/central-publishing-maven-plugin-removal/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/central-publishing-maven-plugin-removal/test.properties
+++ b/integration-test/src/it/central-publishing-maven-plugin-removal/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/central-publishing-maven-plugin-removal/verify.groovy
+++ b/integration-test/src/it/central-publishing-maven-plugin-removal/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/circular-dependencies-test-parent/bom/pom.xml
+++ b/integration-test/src/it/circular-dependencies-test-parent/bom/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/circular-dependencies-test-parent/invoker.properties
+++ b/integration-test/src/it/circular-dependencies-test-parent/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/circular-dependencies-test-parent/pom.xml
+++ b/integration-test/src/it/circular-dependencies-test-parent/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/circular-dependencies-test-second/A/pom.xml
+++ b/integration-test/src/it/circular-dependencies-test-second/A/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/circular-dependencies-test-second/B/C/pom.xml
+++ b/integration-test/src/it/circular-dependencies-test-second/B/C/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/circular-dependencies-test-second/B/pom.xml
+++ b/integration-test/src/it/circular-dependencies-test-second/B/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/circular-dependencies-test-second/Sample.groovy
+++ b/integration-test/src/it/circular-dependencies-test-second/Sample.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.commonjava.atlas.maven.ident.ref.SimpleProjectVersionRef
 import org.jboss.pnc.mavenmanipulator.core.groovy.BaseScript
 import org.jboss.pnc.mavenmanipulator.core.groovy.InvocationPoint

--- a/integration-test/src/it/circular-dependencies-test-second/invoker.properties
+++ b/integration-test/src/it/circular-dependencies-test-second/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/circular-dependencies-test-second/pom.xml
+++ b/integration-test/src/it/circular-dependencies-test-second/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/circular-dependencies-test-second/test.properties
+++ b/integration-test/src/it/circular-dependencies-test-second/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/circular-dependencies-test-second/verify.groovy
+++ b/integration-test/src/it/circular-dependencies-test-second/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/comment-duplication/invoker.properties
+++ b/integration-test/src/it/comment-duplication/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/comment-duplication/pom.xml
+++ b/integration-test/src/it/comment-duplication/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/comment-duplication/setup.groovy
+++ b/integration-test/src/it/comment-duplication/setup.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/comment-duplication/test.properties
+++ b/integration-test/src/it/comment-duplication/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/comment-duplication/verify.groovy
+++ b/integration-test/src/it/comment-duplication/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/config-file-json/invoker.properties
+++ b/integration-test/src/it/config-file-json/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/config-file-json/pom.xml
+++ b/integration-test/src/it/config-file-json/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/config-file-json/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/config-file-json/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/config-file-json/verify.groovy
+++ b/integration-test/src/it/config-file-json/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/config-file-properties-cli-precedence/invoker.properties
+++ b/integration-test/src/it/config-file-properties-cli-precedence/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/config-file-properties-cli-precedence/pme.properties
+++ b/integration-test/src/it/config-file-properties-cli-precedence/pme.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/config-file-properties-cli-precedence/pom.xml
+++ b/integration-test/src/it/config-file-properties-cli-precedence/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/config-file-properties-cli-precedence/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/config-file-properties-cli-precedence/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/config-file-properties-cli-precedence/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/config-file-properties-cli-precedence/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/config-file-properties-cli-precedence/test.properties
+++ b/integration-test/src/it/config-file-properties-cli-precedence/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/config-file-properties-cli-precedence/verify.groovy
+++ b/integration-test/src/it/config-file-properties-cli-precedence/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/config-file-properties/invoker.properties
+++ b/integration-test/src/it/config-file-properties/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/config-file-properties/pme.properties
+++ b/integration-test/src/it/config-file-properties/pme.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/config-file-properties/pom.xml
+++ b/integration-test/src/it/config-file-properties/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/config-file-properties/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/config-file-properties/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/config-file-properties/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/config-file-properties/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/config-file-properties/verify.groovy
+++ b/integration-test/src/it/config-file-properties/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/config-file-yaml/invoker.properties
+++ b/integration-test/src/it/config-file-yaml/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/config-file-yaml/pnc.yaml
+++ b/integration-test/src/it/config-file-yaml/pnc.yaml
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/config-file-yaml/pom.xml
+++ b/integration-test/src/it/config-file-yaml/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/config-file-yaml/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/config-file-yaml/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/config-file-yaml/verify.groovy
+++ b/integration-test/src/it/config-file-yaml/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/dependency-exclusion-deprecated/invoker.properties
+++ b/integration-test/src/it/dependency-exclusion-deprecated/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/dependency-exclusion-deprecated/pom.xml
+++ b/integration-test/src/it/dependency-exclusion-deprecated/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/dependency-exclusion-deprecated/test.properties
+++ b/integration-test/src/it/dependency-exclusion-deprecated/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/dependency-exclusion-deprecated/verify.groovy
+++ b/integration-test/src/it/dependency-exclusion-deprecated/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/dependency-exclusion/pom.xml
+++ b/integration-test/src/it/dependency-exclusion/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/dependency-exclusion/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/dependency-exclusion/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/dependency-exclusion/test.properties
+++ b/integration-test/src/it/dependency-exclusion/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/dependency-exclusion/verify.groovy
+++ b/integration-test/src/it/dependency-exclusion/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/dependency-removal-nodeps/invoker.properties
+++ b/integration-test/src/it/dependency-removal-nodeps/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/dependency-removal-nodeps/pom.xml
+++ b/integration-test/src/it/dependency-removal-nodeps/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/dependency-removal-nodeps/test.properties
+++ b/integration-test/src/it/dependency-removal-nodeps/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/dependency-removal-nodeps/verify.groovy
+++ b/integration-test/src/it/dependency-removal-nodeps/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/dependency-removal/invoker.properties
+++ b/integration-test/src/it/dependency-removal/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/dependency-removal/pom.xml
+++ b/integration-test/src/it/dependency-removal/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/dependency-removal/test.properties
+++ b/integration-test/src/it/dependency-removal/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/dependency-removal/verify.groovy
+++ b/integration-test/src/it/dependency-removal/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-invalid/child1/pom.xml
+++ b/integration-test/src/it/depex-invalid/child1/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-invalid/child1/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/depex-invalid/child1/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-invalid/child1/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/depex-invalid/child1/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-invalid/invoker.properties
+++ b/integration-test/src/it/depex-invalid/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-invalid/pom.xml
+++ b/integration-test/src/it/depex-invalid/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-invalid/test.properties
+++ b/integration-test/src/it/depex-invalid/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-invalid/verify.groovy
+++ b/integration-test/src/it/depex-invalid/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-multiple-wildcard/bom.xml
+++ b/integration-test/src/it/depex-multiple-wildcard/bom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-multiple-wildcard/child1/pom.xml
+++ b/integration-test/src/it/depex-multiple-wildcard/child1/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-multiple-wildcard/child1/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/depex-multiple-wildcard/child1/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-multiple-wildcard/child1/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/depex-multiple-wildcard/child1/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-multiple-wildcard/install.properties
+++ b/integration-test/src/it/depex-multiple-wildcard/install.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-multiple-wildcard/invoker.properties
+++ b/integration-test/src/it/depex-multiple-wildcard/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-multiple-wildcard/pom.xml
+++ b/integration-test/src/it/depex-multiple-wildcard/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-multiple-wildcard/test.properties
+++ b/integration-test/src/it/depex-multiple-wildcard/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-multiple-wildcard/verify.groovy
+++ b/integration-test/src/it/depex-multiple-wildcard/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-wildcard-with-module-override/bom.xml
+++ b/integration-test/src/it/depex-wildcard-with-module-override/bom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-wildcard-with-module-override/child1/pom.xml
+++ b/integration-test/src/it/depex-wildcard-with-module-override/child1/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-wildcard-with-module-override/child1/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/depex-wildcard-with-module-override/child1/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-wildcard-with-module-override/child1/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/depex-wildcard-with-module-override/child1/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-wildcard-with-module-override/child2/pom.xml
+++ b/integration-test/src/it/depex-wildcard-with-module-override/child2/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-wildcard-with-module-override/child2/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/depex-wildcard-with-module-override/child2/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-wildcard-with-module-override/child2/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/depex-wildcard-with-module-override/child2/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-wildcard-with-module-override/install.properties
+++ b/integration-test/src/it/depex-wildcard-with-module-override/install.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-wildcard-with-module-override/invoker.properties
+++ b/integration-test/src/it/depex-wildcard-with-module-override/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-wildcard-with-module-override/pom.xml
+++ b/integration-test/src/it/depex-wildcard-with-module-override/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-wildcard-with-module-override/test.properties
+++ b/integration-test/src/it/depex-wildcard-with-module-override/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-wildcard-with-module-override/verify.groovy
+++ b/integration-test/src/it/depex-wildcard-with-module-override/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-wildcard/bom.xml
+++ b/integration-test/src/it/depex-wildcard/bom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-wildcard/child1/pom.xml
+++ b/integration-test/src/it/depex-wildcard/child1/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-wildcard/child1/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/depex-wildcard/child1/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-wildcard/child1/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/depex-wildcard/child1/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-wildcard/install.properties
+++ b/integration-test/src/it/depex-wildcard/install.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-wildcard/invoker.properties
+++ b/integration-test/src/it/depex-wildcard/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-wildcard/pom.xml
+++ b/integration-test/src/it/depex-wildcard/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-wildcard/test.properties
+++ b/integration-test/src/it/depex-wildcard/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depex-wildcard/verify.groovy
+++ b/integration-test/src/it/depex-wildcard/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/deploy-install-skip-property/invoker.properties
+++ b/integration-test/src/it/deploy-install-skip-property/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/deploy-install-skip-property/pom.xml
+++ b/integration-test/src/it/deploy-install-skip-property/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/deploy-install-skip-property/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/deploy-install-skip-property/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/deploy-install-skip-property/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/deploy-install-skip-property/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/deploy-install-skip-property/test.properties
+++ b/integration-test/src/it/deploy-install-skip-property/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/deploy-install-skip-property/verify.groovy
+++ b/integration-test/src/it/deploy-install-skip-property/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/deploy-install-skip/invoker.properties
+++ b/integration-test/src/it/deploy-install-skip/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/deploy-install-skip/pom.xml
+++ b/integration-test/src/it/deploy-install-skip/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/deploy-install-skip/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/deploy-install-skip/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/deploy-install-skip/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/deploy-install-skip/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/deploy-install-skip/test.properties
+++ b/integration-test/src/it/deploy-install-skip/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/deploy-install-skip/verify.groovy
+++ b/integration-test/src/it/deploy-install-skip/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-override-parent/pom.xml
+++ b/integration-test/src/it/depmgmt-override-parent/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-override-parent/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/depmgmt-override-parent/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-override-parent/test.properties
+++ b/integration-test/src/it/depmgmt-override-parent/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-override-parent/verify.groovy
+++ b/integration-test/src/it/depmgmt-override-parent/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-exact-classifier/invoker.properties
+++ b/integration-test/src/it/depmgmt-strict-mode-exact-classifier/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-exact-classifier/pom.xml
+++ b/integration-test/src/it/depmgmt-strict-mode-exact-classifier/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-exact-classifier/test.properties
+++ b/integration-test/src/it/depmgmt-strict-mode-exact-classifier/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-exact-classifier/verify.groovy
+++ b/integration-test/src/it/depmgmt-strict-mode-exact-classifier/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-exact-existing-rebuild/invoker.properties
+++ b/integration-test/src/it/depmgmt-strict-mode-exact-existing-rebuild/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-exact-existing-rebuild/pom.xml
+++ b/integration-test/src/it/depmgmt-strict-mode-exact-existing-rebuild/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-exact-existing-rebuild/test.properties
+++ b/integration-test/src/it/depmgmt-strict-mode-exact-existing-rebuild/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-exact-existing-rebuild/verify.groovy
+++ b/integration-test/src/it/depmgmt-strict-mode-exact-existing-rebuild/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-exact/child/pom.xml
+++ b/integration-test/src/it/depmgmt-strict-mode-exact/child/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-exact/invoker.properties
+++ b/integration-test/src/it/depmgmt-strict-mode-exact/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-exact/pom.xml
+++ b/integration-test/src/it/depmgmt-strict-mode-exact/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-exact/test.properties
+++ b/integration-test/src/it/depmgmt-strict-mode-exact/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-exact/verify.groovy
+++ b/integration-test/src/it/depmgmt-strict-mode-exact/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-fails/invoker.properties
+++ b/integration-test/src/it/depmgmt-strict-mode-fails/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-fails/pom.xml
+++ b/integration-test/src/it/depmgmt-strict-mode-fails/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-fails/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/depmgmt-strict-mode-fails/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-fails/test.properties
+++ b/integration-test/src/it/depmgmt-strict-mode-fails/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/depmgmt-strict-mode-override-alias/invoker.properties
+++ b/integration-test/src/it/depmgmt-strict-mode-override-alias/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-override-alias/pom.xml
+++ b/integration-test/src/it/depmgmt-strict-mode-override-alias/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-override-alias/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/depmgmt-strict-mode-override-alias/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-override-alias/test.properties
+++ b/integration-test/src/it/depmgmt-strict-mode-override-alias/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 dependencyManagement=org.jboss.pnc.maven-manipulator.integration-test\:depMgmt1\:1.0
 overrideTransitive=false

--- a/integration-test/src/it/depmgmt-strict-mode-override-alias/verify.groovy
+++ b/integration-test/src/it/depmgmt-strict-mode-override-alias/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-override/invoker.properties
+++ b/integration-test/src/it/depmgmt-strict-mode-override/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-override/pom.xml
+++ b/integration-test/src/it/depmgmt-strict-mode-override/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-override/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/depmgmt-strict-mode-override/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-override/test.properties
+++ b/integration-test/src/it/depmgmt-strict-mode-override/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 dependencyManagement=org.jboss.pnc.maven-manipulator.integration-test\:depMgmt1\:1.0
 overrideTransitive=false

--- a/integration-test/src/it/depmgmt-strict-mode-override/verify.groovy
+++ b/integration-test/src/it/depmgmt-strict-mode-override/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-report-only/pom.xml
+++ b/integration-test/src/it/depmgmt-strict-mode-report-only/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-report-only/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/depmgmt-strict-mode-report-only/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/depmgmt-strict-mode-report-only/test.properties
+++ b/integration-test/src/it/depmgmt-strict-mode-report-only/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/depmgmt-strict-mode-report-only/verify.groovy
+++ b/integration-test/src/it/depmgmt-strict-mode-report-only/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/dual-property-exclusion/child/pom.xml
+++ b/integration-test/src/it/dual-property-exclusion/child/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/dual-property-exclusion/pom.xml
+++ b/integration-test/src/it/dual-property-exclusion/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/dual-property-exclusion/test.properties
+++ b/integration-test/src/it/dual-property-exclusion/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/dual-property-exclusion/verify.groovy
+++ b/integration-test/src/it/dual-property-exclusion/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/duplicate-dependency-plugins/child/pom.xml
+++ b/integration-test/src/it/duplicate-dependency-plugins/child/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/duplicate-dependency-plugins/child/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/duplicate-dependency-plugins/child/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/duplicate-dependency-plugins/pom.xml
+++ b/integration-test/src/it/duplicate-dependency-plugins/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/duplicate-dependency-plugins/test.properties
+++ b/integration-test/src/it/duplicate-dependency-plugins/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/duplicate-dependency-plugins/verify.groovy
+++ b/integration-test/src/it/duplicate-dependency-plugins/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/excluded-scope/child/pom.xml
+++ b/integration-test/src/it/excluded-scope/child/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/excluded-scope/invoker.properties
+++ b/integration-test/src/it/excluded-scope/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/excluded-scope/pom.xml
+++ b/integration-test/src/it/excluded-scope/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/excluded-scope/test.properties
+++ b/integration-test/src/it/excluded-scope/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/excluded-scope/verify.groovy
+++ b/integration-test/src/it/excluded-scope/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/expression-not-rewritten/invoker.properties
+++ b/integration-test/src/it/expression-not-rewritten/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/expression-not-rewritten/pom.xml
+++ b/integration-test/src/it/expression-not-rewritten/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/expression-not-rewritten/test.properties
+++ b/integration-test/src/it/expression-not-rewritten/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/expression-not-rewritten/verify.groovy
+++ b/integration-test/src/it/expression-not-rewritten/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-all/invoker.properties
+++ b/integration-test/src/it/groovy-manipulator-all/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-all/pom.xml
+++ b/integration-test/src/it/groovy-manipulator-all/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-all/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/groovy-manipulator-all/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-all/test.properties
+++ b/integration-test/src/it/groovy-manipulator-all/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-all/verify.groovy
+++ b/integration-test/src/it/groovy-manipulator-all/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-all/writeInvocationStage.groovy
+++ b/integration-test/src/it/groovy-manipulator-all/writeInvocationStage.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-bad/invoker.properties
+++ b/integration-test/src/it/groovy-manipulator-bad/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-bad/pom.xml
+++ b/integration-test/src/it/groovy-manipulator-bad/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-bad/test.properties
+++ b/integration-test/src/it/groovy-manipulator-bad/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-both/pom.xml
+++ b/integration-test/src/it/groovy-manipulator-both/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-both/test.properties
+++ b/integration-test/src/it/groovy-manipulator-both/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-both/verify.groovy
+++ b/integration-test/src/it/groovy-manipulator-both/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-file/pom.xml
+++ b/integration-test/src/it/groovy-manipulator-file/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-file/test.properties
+++ b/integration-test/src/it/groovy-manipulator-file/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it
 groovyScripts=file://${basedir}/src/it/setup/depMgmt1/Sample.groovy

--- a/integration-test/src/it/groovy-manipulator-file/verify.groovy
+++ b/integration-test/src/it/groovy-manipulator-file/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-first-http/pom.xml
+++ b/integration-test/src/it/groovy-manipulator-first-http/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-first-http/test.properties
+++ b/integration-test/src/it/groovy-manipulator-first-http/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-first-http/verify.groovy
+++ b/integration-test/src/it/groovy-manipulator-first-http/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-first/pom.xml
+++ b/integration-test/src/it/groovy-manipulator-first/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-first/test.properties
+++ b/integration-test/src/it/groovy-manipulator-first/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-first/verify.groovy
+++ b/integration-test/src/it/groovy-manipulator-first/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-preparse/invoker.properties
+++ b/integration-test/src/it/groovy-manipulator-preparse/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-preparse/modifyPom.groovy
+++ b/integration-test/src/it/groovy-manipulator-preparse/modifyPom.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-preparse/pom.xml
+++ b/integration-test/src/it/groovy-manipulator-preparse/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-preparse/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/groovy-manipulator-preparse/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-preparse/test.properties
+++ b/integration-test/src/it/groovy-manipulator-preparse/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator-preparse/verify.groovy
+++ b/integration-test/src/it/groovy-manipulator-preparse/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator/pom.xml
+++ b/integration-test/src/it/groovy-manipulator/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/groovy-manipulator/test.properties
+++ b/integration-test/src/it/groovy-manipulator/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it
 groovyScripts=org.jboss.pnc.maven-manipulator.integration-test\:depMgmt1\:groovy\:1.0

--- a/integration-test/src/it/groovy-manipulator/verify.groovy
+++ b/integration-test/src/it/groovy-manipulator/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/incremental-static-suffix-interaction/invoker.properties
+++ b/integration-test/src/it/incremental-static-suffix-interaction/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 invoker.goals=install -Dmanipulation.disable=true
 invoker.goals.2=install

--- a/integration-test/src/it/incremental-static-suffix-interaction/pom.xml
+++ b/integration-test/src/it/incremental-static-suffix-interaction/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/incremental-static-suffix-interaction/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/incremental-static-suffix-interaction/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/incremental-static-suffix-interaction/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/incremental-static-suffix-interaction/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/incremental-static-suffix-interaction/test.properties
+++ b/integration-test/src/it/incremental-static-suffix-interaction/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/incremental-static-suffix-interaction/verify.groovy
+++ b/integration-test/src/it/incremental-static-suffix-interaction/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/inline-property-managed-plugin-section/inlineProp.groovy
+++ b/integration-test/src/it/inline-property-managed-plugin-section/inlineProp.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/inline-property-managed-plugin-section/invoker.properties
+++ b/integration-test/src/it/inline-property-managed-plugin-section/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/inline-property-managed-plugin-section/pom.xml
+++ b/integration-test/src/it/inline-property-managed-plugin-section/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/inline-property-managed-plugin-section/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/inline-property-managed-plugin-section/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/inline-property-managed-plugin-section/test.properties
+++ b/integration-test/src/it/inline-property-managed-plugin-section/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/inline-property-managed-plugin-section/verify.groovy
+++ b/integration-test/src/it/inline-property-managed-plugin-section/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/inline-property-plugin-section/inlineProp.groovy
+++ b/integration-test/src/it/inline-property-plugin-section/inlineProp.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/inline-property-plugin-section/invoker.properties
+++ b/integration-test/src/it/inline-property-plugin-section/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/inline-property-plugin-section/pom.xml
+++ b/integration-test/src/it/inline-property-plugin-section/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/inline-property-plugin-section/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/inline-property-plugin-section/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/inline-property-plugin-section/test.properties
+++ b/integration-test/src/it/inline-property-plugin-section/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/inline-property-plugin-section/verify.groovy
+++ b/integration-test/src/it/inline-property-plugin-section/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/marker-file/invoker.properties
+++ b/integration-test/src/it/marker-file/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/marker-file/pom.xml
+++ b/integration-test/src/it/marker-file/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/marker-file/test.properties
+++ b/integration-test/src/it/marker-file/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/marker-file/verify.groovy
+++ b/integration-test/src/it/marker-file/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/nexus-staging-maven-plugin-removal-disabled/invoker.properties
+++ b/integration-test/src/it/nexus-staging-maven-plugin-removal-disabled/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/nexus-staging-maven-plugin-removal-disabled/pom.xml
+++ b/integration-test/src/it/nexus-staging-maven-plugin-removal-disabled/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/nexus-staging-maven-plugin-removal-disabled/test.properties
+++ b/integration-test/src/it/nexus-staging-maven-plugin-removal-disabled/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/nexus-staging-maven-plugin-removal-disabled/verify.groovy
+++ b/integration-test/src/it/nexus-staging-maven-plugin-removal-disabled/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/nexus-staging-maven-plugin-removal-no-build/invoker.properties
+++ b/integration-test/src/it/nexus-staging-maven-plugin-removal-no-build/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/nexus-staging-maven-plugin-removal-no-build/pom.xml
+++ b/integration-test/src/it/nexus-staging-maven-plugin-removal-no-build/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/nexus-staging-maven-plugin-removal-no-build/test.properties
+++ b/integration-test/src/it/nexus-staging-maven-plugin-removal-no-build/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/nexus-staging-maven-plugin-removal-no-build/verify.groovy
+++ b/integration-test/src/it/nexus-staging-maven-plugin-removal-no-build/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/nexus-staging-maven-plugin-removal-non-build-profile/invoker.properties
+++ b/integration-test/src/it/nexus-staging-maven-plugin-removal-non-build-profile/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/nexus-staging-maven-plugin-removal-non-build-profile/pom.xml
+++ b/integration-test/src/it/nexus-staging-maven-plugin-removal-non-build-profile/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/nexus-staging-maven-plugin-removal-non-build-profile/test.properties
+++ b/integration-test/src/it/nexus-staging-maven-plugin-removal-non-build-profile/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/nexus-staging-maven-plugin-removal-non-build-profile/verify.groovy
+++ b/integration-test/src/it/nexus-staging-maven-plugin-removal-non-build-profile/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/nexus-staging-maven-plugin-removal/invoker.properties
+++ b/integration-test/src/it/nexus-staging-maven-plugin-removal/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/nexus-staging-maven-plugin-removal/pom.xml
+++ b/integration-test/src/it/nexus-staging-maven-plugin-removal/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/nexus-staging-maven-plugin-removal/test.properties
+++ b/integration-test/src/it/nexus-staging-maven-plugin-removal/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/nexus-staging-maven-plugin-removal/verify.groovy
+++ b/integration-test/src/it/nexus-staging-maven-plugin-removal/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-checkstyle-plugin/child/pom.xml
+++ b/integration-test/src/it/parent-child-checkstyle-plugin/child/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-checkstyle-plugin/child/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/parent-child-checkstyle-plugin/child/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-checkstyle-plugin/child/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/parent-child-checkstyle-plugin/child/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-checkstyle-plugin/invoker.properties
+++ b/integration-test/src/it/parent-child-checkstyle-plugin/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-checkstyle-plugin/pom.xml
+++ b/integration-test/src/it/parent-child-checkstyle-plugin/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-checkstyle-plugin/test.properties
+++ b/integration-test/src/it/parent-child-checkstyle-plugin/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-checkstyle-plugin/verify.groovy
+++ b/integration-test/src/it/parent-child-checkstyle-plugin/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-inherit-bom-generation/child/pom.xml
+++ b/integration-test/src/it/parent-child-inherit-bom-generation/child/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-inherit-bom-generation/child/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/parent-child-inherit-bom-generation/child/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-inherit-bom-generation/child/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/parent-child-inherit-bom-generation/child/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-inherit-bom-generation/invoker.properties
+++ b/integration-test/src/it/parent-child-inherit-bom-generation/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-inherit-bom-generation/pom.xml
+++ b/integration-test/src/it/parent-child-inherit-bom-generation/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-inherit-bom-generation/test.properties
+++ b/integration-test/src/it/parent-child-inherit-bom-generation/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-inherit-bom-generation/verify.groovy
+++ b/integration-test/src/it/parent-child-inherit-bom-generation/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-inherit/child/pom.xml
+++ b/integration-test/src/it/parent-child-inherit/child/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-inherit/child/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/parent-child-inherit/child/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-inherit/child/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/parent-child-inherit/child/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-inherit/invoker.properties
+++ b/integration-test/src/it/parent-child-inherit/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-inherit/pom.xml
+++ b/integration-test/src/it/parent-child-inherit/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-inherit/test.properties
+++ b/integration-test/src/it/parent-child-inherit/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-inherit/verify.groovy
+++ b/integration-test/src/it/parent-child-inherit/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-profile-version/child1/pom.xml
+++ b/integration-test/src/it/parent-child-profile-version/child1/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-profile-version/child1/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/parent-child-profile-version/child1/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-profile-version/child2/pom.xml
+++ b/integration-test/src/it/parent-child-profile-version/child2/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-profile-version/child2/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/parent-child-profile-version/child2/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-profile-version/child2/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/parent-child-profile-version/child2/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-profile-version/pom.xml
+++ b/integration-test/src/it/parent-child-profile-version/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-profile-version/test.properties
+++ b/integration-test/src/it/parent-child-profile-version/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-child-profile-version/verify.groovy
+++ b/integration-test/src/it/parent-child-profile-version/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-children-interdep-expr/child1/pom.xml
+++ b/integration-test/src/it/parent-children-interdep-expr/child1/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-children-interdep-expr/child1/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/parent-children-interdep-expr/child1/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-children-interdep-expr/child1/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/parent-children-interdep-expr/child1/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-children-interdep-expr/child2/pom.xml
+++ b/integration-test/src/it/parent-children-interdep-expr/child2/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-children-interdep-expr/child2/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/parent-children-interdep-expr/child2/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-children-interdep-expr/child2/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/parent-children-interdep-expr/child2/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-children-interdep-expr/invoker.properties
+++ b/integration-test/src/it/parent-children-interdep-expr/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-children-interdep-expr/pom.xml
+++ b/integration-test/src/it/parent-children-interdep-expr/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-children-interdep-expr/test.properties
+++ b/integration-test/src/it/parent-children-interdep-expr/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-children-interdep-expr/verify.groovy
+++ b/integration-test/src/it/parent-children-interdep-expr/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-children-interdep/child1/pom.xml
+++ b/integration-test/src/it/parent-children-interdep/child1/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-children-interdep/child1/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/parent-children-interdep/child1/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-children-interdep/child1/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/parent-children-interdep/child1/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-children-interdep/child2/pom.xml
+++ b/integration-test/src/it/parent-children-interdep/child2/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-children-interdep/child2/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/parent-children-interdep/child2/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-children-interdep/child2/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/parent-children-interdep/child2/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-children-interdep/invoker.properties
+++ b/integration-test/src/it/parent-children-interdep/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-children-interdep/pom.xml
+++ b/integration-test/src/it/parent-children-interdep/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-children-interdep/test.properties
+++ b/integration-test/src/it/parent-children-interdep/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-children-interdep/verify.groovy
+++ b/integration-test/src/it/parent-children-interdep/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-injection-basic/pom.xml
+++ b/integration-test/src/it/parent-injection-basic/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/parent-injection-basic/test.properties
+++ b/integration-test/src/it/parent-injection-basic/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the repositories
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/parent-injection-basic/verify.groovy
+++ b/integration-test/src/it/parent-injection-basic/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/plugin-override/pom.xml
+++ b/integration-test/src/it/plugin-override/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/plugin-override/test.properties
+++ b/integration-test/src/it/plugin-override/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/plugin-override/verify.groovy
+++ b/integration-test/src/it/plugin-override/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/plugin-removal-no-build/invoker.properties
+++ b/integration-test/src/it/plugin-removal-no-build/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/plugin-removal-no-build/pom.xml
+++ b/integration-test/src/it/plugin-removal-no-build/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/plugin-removal-no-build/test.properties
+++ b/integration-test/src/it/plugin-removal-no-build/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/plugin-removal-no-build/verify.groovy
+++ b/integration-test/src/it/plugin-removal-no-build/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/plugin-removal-nonbuild-profile/invoker.properties
+++ b/integration-test/src/it/plugin-removal-nonbuild-profile/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/plugin-removal-nonbuild-profile/pom.xml
+++ b/integration-test/src/it/plugin-removal-nonbuild-profile/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/plugin-removal-nonbuild-profile/test.properties
+++ b/integration-test/src/it/plugin-removal-nonbuild-profile/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/plugin-removal-nonbuild-profile/verify.groovy
+++ b/integration-test/src/it/plugin-removal-nonbuild-profile/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/plugin-removal/invoker.properties
+++ b/integration-test/src/it/plugin-removal/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/plugin-removal/pom.xml
+++ b/integration-test/src/it/plugin-removal/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/plugin-removal/test.properties
+++ b/integration-test/src/it/plugin-removal/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/plugin-removal/verify.groovy
+++ b/integration-test/src/it/plugin-removal/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/pom-extension/.mvn/extensions.xml
+++ b/integration-test/src/it/pom-extension/.mvn/extensions.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/pom-extension/invoker.properties
+++ b/integration-test/src/it/pom-extension/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/pom-extension/pom.xml
+++ b/integration-test/src/it/pom-extension/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/pom-extension/test.properties
+++ b/integration-test/src/it/pom-extension/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/pom-extension/verify.groovy
+++ b/integration-test/src/it/pom-extension/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/profile-injection-basic-multiple/pom.xml
+++ b/integration-test/src/it/profile-injection-basic-multiple/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/profile-injection-basic-multiple/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/profile-injection-basic-multiple/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/profile-injection-basic-multiple/test.properties
+++ b/integration-test/src/it/profile-injection-basic-multiple/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/profile-injection-basic-multiple/verify.groovy
+++ b/integration-test/src/it/profile-injection-basic-multiple/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/profile-injection-basic/pom.xml
+++ b/integration-test/src/it/profile-injection-basic/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/profile-injection-basic/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/profile-injection-basic/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/profile-injection-basic/test.properties
+++ b/integration-test/src/it/profile-injection-basic/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/profile-injection-basic/verify.groovy
+++ b/integration-test/src/it/profile-injection-basic/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/profile-injection-dependency/pom.xml
+++ b/integration-test/src/it/profile-injection-dependency/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/profile-injection-dependency/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/profile-injection-dependency/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/profile-injection-dependency/test.properties
+++ b/integration-test/src/it/profile-injection-dependency/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/profile-injection-dependency/verify.groovy
+++ b/integration-test/src/it/profile-injection-dependency/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/profile-removal/invoker.properties
+++ b/integration-test/src/it/profile-removal/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/profile-removal/pom.xml
+++ b/integration-test/src/it/profile-removal/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/profile-removal/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/profile-removal/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/profile-removal/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/profile-removal/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/profile-removal/test.properties
+++ b/integration-test/src/it/profile-removal/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/profile-removal/verify.groovy
+++ b/integration-test/src/it/profile-removal/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-inheritance/common/config/pom.xml
+++ b/integration-test/src/it/project-inheritance/common/config/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-inheritance/common/pom.xml
+++ b/integration-test/src/it/project-inheritance/common/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-inheritance/invoker.properties
+++ b/integration-test/src/it/project-inheritance/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-inheritance/pom.xml
+++ b/integration-test/src/it/project-inheritance/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-inheritance/test.properties
+++ b/integration-test/src/it/project-inheritance/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/project-inheritance/verify.groovy
+++ b/integration-test/src/it/project-inheritance/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-sources-injection-basic/invoker.properties
+++ b/integration-test/src/it/project-sources-injection-basic/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-sources-injection-basic/pom.xml
+++ b/integration-test/src/it/project-sources-injection-basic/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-sources-injection-basic/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/project-sources-injection-basic/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-sources-injection-basic/test.properties
+++ b/integration-test/src/it/project-sources-injection-basic/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Add another manipulator to ensure the project-sources manipulator is activated.
 repoReportingRemoval=true

--- a/integration-test/src/it/project-sources-injection-basic/verify.groovy
+++ b/integration-test/src/it/project-sources-injection-basic/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-version-child-property-version/child/pom.xml
+++ b/integration-test/src/it/project-version-child-property-version/child/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-version-child-property-version/invoker.properties
+++ b/integration-test/src/it/project-version-child-property-version/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-version-child-property-version/pom.xml
+++ b/integration-test/src/it/project-version-child-property-version/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-version-child-property-version/test.properties
+++ b/integration-test/src/it/project-version-child-property-version/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-version-child-property-version/verify.groovy
+++ b/integration-test/src/it/project-version-child-property-version/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-version-child/child/pom.xml
+++ b/integration-test/src/it/project-version-child/child/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-version-child/invoker.properties
+++ b/integration-test/src/it/project-version-child/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-version-child/pom.xml
+++ b/integration-test/src/it/project-version-child/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-version-child/test.properties
+++ b/integration-test/src/it/project-version-child/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-version-child/verify.groovy
+++ b/integration-test/src/it/project-version-child/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-version-disabled/invoker.properties
+++ b/integration-test/src/it/project-version-disabled/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-version-disabled/pom.xml
+++ b/integration-test/src/it/project-version-disabled/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-version-disabled/test.properties
+++ b/integration-test/src/it/project-version-disabled/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-version-disabled/verify.groovy
+++ b/integration-test/src/it/project-version-disabled/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-version-static/child/pom.xml
+++ b/integration-test/src/it/project-version-static/child/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-version-static/invoker.properties
+++ b/integration-test/src/it/project-version-static/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-version-static/pom.xml
+++ b/integration-test/src/it/project-version-static/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-version-static/test.properties
+++ b/integration-test/src/it/project-version-static/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-version-static/verify.groovy
+++ b/integration-test/src/it/project-version-static/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-version/invoker.properties
+++ b/integration-test/src/it/project-version/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-version/pom.xml
+++ b/integration-test/src/it/project-version/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-version/test.properties
+++ b/integration-test/src/it/project-version/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/project-version/verify.groovy
+++ b/integration-test/src/it/project-version/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/property-clash-force/invoker.properties
+++ b/integration-test/src/it/property-clash-force/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/property-clash-force/pom.xml
+++ b/integration-test/src/it/property-clash-force/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/property-clash-force/test.properties
+++ b/integration-test/src/it/property-clash-force/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/property-clash-force/verify.groovy
+++ b/integration-test/src/it/property-clash-force/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/property-clash-override/invoker.properties
+++ b/integration-test/src/it/property-clash-override/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/property-clash-override/pom.xml
+++ b/integration-test/src/it/property-clash-override/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/property-clash-override/test.properties
+++ b/integration-test/src/it/property-clash-override/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/property-clash-override/verify.groovy
+++ b/integration-test/src/it/property-clash-override/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/property-clash-warn-only/invoker.properties
+++ b/integration-test/src/it/property-clash-warn-only/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/property-clash-warn-only/pom.xml
+++ b/integration-test/src/it/property-clash-warn-only/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/property-clash-warn-only/test.properties
+++ b/integration-test/src/it/property-clash-warn-only/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/property-clash-warn-only/verify.groovy
+++ b/integration-test/src/it/property-clash-warn-only/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/property-clash/invoker.properties
+++ b/integration-test/src/it/property-clash/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/property-clash/pom.xml
+++ b/integration-test/src/it/property-clash/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/property-clash/test.properties
+++ b/integration-test/src/it/property-clash/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/property-clash/verify.groovy
+++ b/integration-test/src/it/property-clash/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/property-injection-transitive/pom.xml
+++ b/integration-test/src/it/property-injection-transitive/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/property-injection-transitive/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/property-injection-transitive/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/property-injection-transitive/test.properties
+++ b/integration-test/src/it/property-injection-transitive/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/property-injection-transitive/verify.groovy
+++ b/integration-test/src/it/property-injection-transitive/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/relocation-artifact/invoker.properties
+++ b/integration-test/src/it/relocation-artifact/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/relocation-artifact/pom.xml
+++ b/integration-test/src/it/relocation-artifact/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/relocation-artifact/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/relocation-artifact/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/relocation-artifact/test.properties
+++ b/integration-test/src/it/relocation-artifact/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/relocation-artifact/verify.groovy
+++ b/integration-test/src/it/relocation-artifact/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/relocation-group/invoker.properties
+++ b/integration-test/src/it/relocation-group/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/relocation-group/pom.xml
+++ b/integration-test/src/it/relocation-group/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/relocation-group/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/relocation-group/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/relocation-group/test.properties
+++ b/integration-test/src/it/relocation-group/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/relocation-group/verify.groovy
+++ b/integration-test/src/it/relocation-group/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/relocation-multiple/invoker.properties
+++ b/integration-test/src/it/relocation-multiple/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/relocation-multiple/pom.xml
+++ b/integration-test/src/it/relocation-multiple/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/relocation-multiple/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/relocation-multiple/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/relocation-multiple/test.properties
+++ b/integration-test/src/it/relocation-multiple/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/relocation-multiple/verify.groovy
+++ b/integration-test/src/it/relocation-multiple/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/relocation-plugin/invoker.properties
+++ b/integration-test/src/it/relocation-plugin/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/relocation-plugin/pom.xml
+++ b/integration-test/src/it/relocation-plugin/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/relocation-plugin/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/relocation-plugin/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/relocation-plugin/test.properties
+++ b/integration-test/src/it/relocation-plugin/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/relocation-plugin/verify.groovy
+++ b/integration-test/src/it/relocation-plugin/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-depMgmt-bom-of-boms-first-wins/bom-of-boms.xml
+++ b/integration-test/src/it/remote-depMgmt-bom-of-boms-first-wins/bom-of-boms.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-depMgmt-bom-of-boms-first-wins/install.properties
+++ b/integration-test/src/it/remote-depMgmt-bom-of-boms-first-wins/install.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-depMgmt-bom-of-boms-first-wins/invoker.properties
+++ b/integration-test/src/it/remote-depMgmt-bom-of-boms-first-wins/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-depMgmt-bom-of-boms-first-wins/pom.xml
+++ b/integration-test/src/it/remote-depMgmt-bom-of-boms-first-wins/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-depMgmt-bom-of-boms-first-wins/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-depMgmt-bom-of-boms-first-wins/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-depMgmt-bom-of-boms-first-wins/test.properties
+++ b/integration-test/src/it/remote-depMgmt-bom-of-boms-first-wins/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-depMgmt-bom-of-boms-first-wins/verify.groovy
+++ b/integration-test/src/it/remote-depMgmt-bom-of-boms-first-wins/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-basic-classifier/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-basic-classifier/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-basic-classifier/test.properties
+++ b/integration-test/src/it/remote-dependency-management-basic-classifier/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-basic-classifier/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-basic-classifier/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-basic-snapshot-bom/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-basic-snapshot-bom/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-basic-snapshot-bom/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-basic-snapshot-bom/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-basic-snapshot-bom/test.properties
+++ b/integration-test/src/it/remote-dependency-management-basic-snapshot-bom/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-basic-snapshot-bom/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-basic-snapshot-bom/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-basic/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-basic/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-basic/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-basic/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-basic/test.properties
+++ b/integration-test/src/it/remote-dependency-management-basic/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-basic/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-basic/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-exclusion-wildcard-groupid/child/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-child-module-exclusion-wildcard-groupid/child/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-exclusion-wildcard-groupid/child/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-child-module-exclusion-wildcard-groupid/child/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-exclusion-wildcard-groupid/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-child-module-exclusion-wildcard-groupid/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-exclusion-wildcard-groupid/test.properties
+++ b/integration-test/src/it/remote-dependency-management-child-module-exclusion-wildcard-groupid/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-child-module-exclusion-wildcard-groupid/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-child-module-exclusion-wildcard-groupid/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-exclusion-wildcard/child/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-child-module-exclusion-wildcard/child/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-exclusion-wildcard/child/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-child-module-exclusion-wildcard/child/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-exclusion-wildcard/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-child-module-exclusion-wildcard/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-exclusion-wildcard/test.properties
+++ b/integration-test/src/it/remote-dependency-management-child-module-exclusion-wildcard/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-child-module-exclusion-wildcard/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-child-module-exclusion-wildcard/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-exclusion/child/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-child-module-exclusion/child/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-exclusion/child/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-child-module-exclusion/child/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-exclusion/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-child-module-exclusion/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-exclusion/test.properties
+++ b/integration-test/src/it/remote-dependency-management-child-module-exclusion/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-child-module-exclusion/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-child-module-exclusion/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-profiles-scan-active-only-inactive/child/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-child-module-profiles-scan-active-only-inactive/child/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-profiles-scan-active-only-inactive/invoker.properties
+++ b/integration-test/src/it/remote-dependency-management-child-module-profiles-scan-active-only-inactive/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-profiles-scan-active-only-inactive/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-child-module-profiles-scan-active-only-inactive/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-profiles-scan-active-only-inactive/test.properties
+++ b/integration-test/src/it/remote-dependency-management-child-module-profiles-scan-active-only-inactive/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-child-module-profiles-scan-active-only-inactive/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-child-module-profiles-scan-active-only-inactive/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-profiles-scan-active-only/child/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-child-module-profiles-scan-active-only/child/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-profiles-scan-active-only/invoker.properties
+++ b/integration-test/src/it/remote-dependency-management-child-module-profiles-scan-active-only/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-profiles-scan-active-only/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-child-module-profiles-scan-active-only/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-profiles-scan-active-only/test.properties
+++ b/integration-test/src/it/remote-dependency-management-child-module-profiles-scan-active-only/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-child-module-profiles-scan-active-only/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-child-module-profiles-scan-active-only/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-profiles/child/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-child-module-profiles/child/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-profiles/child/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-child-module-profiles/child/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-profiles/invoker.properties
+++ b/integration-test/src/it/remote-dependency-management-child-module-profiles/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-profiles/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-child-module-profiles/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-profiles/test.properties
+++ b/integration-test/src/it/remote-dependency-management-child-module-profiles/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-child-module-profiles/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-child-module-profiles/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-standalone-override-transitive/child/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-child-module-standalone-override-transitive/child/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-standalone-override-transitive/child/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-child-module-standalone-override-transitive/child/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-standalone-override-transitive/invoker.properties
+++ b/integration-test/src/it/remote-dependency-management-child-module-standalone-override-transitive/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-standalone-override-transitive/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-child-module-standalone-override-transitive/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-standalone-override-transitive/settings.xml
+++ b/integration-test/src/it/remote-dependency-management-child-module-standalone-override-transitive/settings.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-standalone-override-transitive/test.properties
+++ b/integration-test/src/it/remote-dependency-management-child-module-standalone-override-transitive/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-child-module-standalone-override-transitive/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-child-module-standalone-override-transitive/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-standalone/child/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-child-module-standalone/child/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-standalone/child/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-child-module-standalone/child/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-standalone/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-child-module-standalone/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module-standalone/test.properties
+++ b/integration-test/src/it/remote-dependency-management-child-module-standalone/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-child-module-standalone/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-child-module-standalone/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module/child/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-child-module/child/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module/child/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-child-module/child/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-child-module/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-module/test.properties
+++ b/integration-test/src/it/remote-dependency-management-child-module/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-child-module/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-child-module/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-modules-complex-properties/child/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-child-modules-complex-properties/child/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-modules-complex-properties/child/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-child-modules-complex-properties/child/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-modules-complex-properties/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-child-modules-complex-properties/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-child-modules-complex-properties/test.properties
+++ b/integration-test/src/it/remote-dependency-management-child-modules-complex-properties/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-child-modules-complex-properties/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-child-modules-complex-properties/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-dependency-injection/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-dependency-injection/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-dependency-injection/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-dependency-injection/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-dependency-injection/test.properties
+++ b/integration-test/src/it/remote-dependency-management-dependency-injection/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-dependency-injection/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-dependency-injection/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-embedded-props-strict-child/child/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-embedded-props-strict-child/child/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-embedded-props-strict-child/invoker.properties
+++ b/integration-test/src/it/remote-dependency-management-embedded-props-strict-child/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-embedded-props-strict-child/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-embedded-props-strict-child/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-embedded-props-strict-child/test.properties
+++ b/integration-test/src/it/remote-dependency-management-embedded-props-strict-child/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-embedded-props-strict-child/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-embedded-props-strict-child/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-embedded-props-strict-ignoresuffix/invoker.properties
+++ b/integration-test/src/it/remote-dependency-management-embedded-props-strict-ignoresuffix/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-embedded-props-strict-ignoresuffix/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-embedded-props-strict-ignoresuffix/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-embedded-props-strict-ignoresuffix/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-embedded-props-strict-ignoresuffix/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-embedded-props-strict-ignoresuffix/test.properties
+++ b/integration-test/src/it/remote-dependency-management-embedded-props-strict-ignoresuffix/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-embedded-props-strict-ignoresuffix/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-embedded-props-strict-ignoresuffix/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-embedded-props-strict-property-clash/invoker.properties
+++ b/integration-test/src/it/remote-dependency-management-embedded-props-strict-property-clash/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-embedded-props-strict-property-clash/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-embedded-props-strict-property-clash/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-embedded-props-strict-property-clash/test.properties
+++ b/integration-test/src/it/remote-dependency-management-embedded-props-strict-property-clash/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-embedded-props-strict/inlineProp.groovy
+++ b/integration-test/src/it/remote-dependency-management-embedded-props-strict/inlineProp.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-embedded-props-strict/invoker.properties
+++ b/integration-test/src/it/remote-dependency-management-embedded-props-strict/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-embedded-props-strict/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-embedded-props-strict/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-embedded-props-strict/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-embedded-props-strict/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-embedded-props-strict/test.properties
+++ b/integration-test/src/it/remote-dependency-management-embedded-props-strict/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-embedded-props-strict/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-embedded-props-strict/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-embedded-props/invoker.properties
+++ b/integration-test/src/it/remote-dependency-management-embedded-props/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-embedded-props/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-embedded-props/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-embedded-props/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-embedded-props/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-embedded-props/test.properties
+++ b/integration-test/src/it/remote-dependency-management-embedded-props/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-embedded-props/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-embedded-props/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-explicit-exclusion-ordering/child/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-explicit-exclusion-ordering/child/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-explicit-exclusion-ordering/child/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-explicit-exclusion-ordering/child/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-explicit-exclusion-ordering/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-explicit-exclusion-ordering/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-explicit-exclusion-ordering/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-explicit-exclusion-ordering/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-explicit-exclusion-ordering/test.properties
+++ b/integration-test/src/it/remote-dependency-management-explicit-exclusion-ordering/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-explicit-exclusion-ordering/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-explicit-exclusion-ordering/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-explicit-exclusion/child/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-explicit-exclusion/child/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-explicit-exclusion/child/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-explicit-exclusion/child/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-explicit-exclusion/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-explicit-exclusion/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-explicit-exclusion/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-explicit-exclusion/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-explicit-exclusion/test.properties
+++ b/integration-test/src/it/remote-dependency-management-explicit-exclusion/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-explicit-exclusion/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-explicit-exclusion/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-extrabom/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-extrabom/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-extrabom/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-extrabom/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-extrabom/test.properties
+++ b/integration-test/src/it/remote-dependency-management-extrabom/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-extrabom/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-extrabom/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-mixed-suffix/invoker.properties
+++ b/integration-test/src/it/remote-dependency-management-mixed-suffix/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-mixed-suffix/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-mixed-suffix/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-mixed-suffix/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-mixed-suffix/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-mixed-suffix/test.properties
+++ b/integration-test/src/it/remote-dependency-management-mixed-suffix/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-mixed-suffix/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-mixed-suffix/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-multiple/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-multiple/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-multiple/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-multiple/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-multiple/test.properties
+++ b/integration-test/src/it/remote-dependency-management-multiple/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-multiple/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-multiple/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-null/bom.xml
+++ b/integration-test/src/it/remote-dependency-management-null/bom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-null/install.properties
+++ b/integration-test/src/it/remote-dependency-management-null/install.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-null/invoker.properties
+++ b/integration-test/src/it/remote-dependency-management-null/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-null/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-null/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-null/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-null/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-null/test.properties
+++ b/integration-test/src/it/remote-dependency-management-null/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-null/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-null/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-parent/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-parent/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-parent/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-parent/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-parent/test.properties
+++ b/integration-test/src/it/remote-dependency-management-parent/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-parent/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-parent/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-plugins/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-plugins/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-plugins/test.properties
+++ b/integration-test/src/it/remote-dependency-management-plugins/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-plugins/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-plugins/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-profiles-scan-active-only-activation/invoker.properties
+++ b/integration-test/src/it/remote-dependency-management-profiles-scan-active-only-activation/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-profiles-scan-active-only-activation/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-profiles-scan-active-only-activation/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-profiles-scan-active-only-activation/test.properties
+++ b/integration-test/src/it/remote-dependency-management-profiles-scan-active-only-activation/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-profiles-scan-active-only-activation/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-profiles-scan-active-only-activation/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-project-version/invoker.properties
+++ b/integration-test/src/it/remote-dependency-management-project-version/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-project-version/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-project-version/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-project-version/test.properties
+++ b/integration-test/src/it/remote-dependency-management-project-version/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-project-version/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-project-version/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-property-children/child/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-property-children/child/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-property-children/child/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-property-children/child/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-property-children/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-property-children/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-property-children/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-property-children/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-property-children/test.properties
+++ b/integration-test/src/it/remote-dependency-management-property-children/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-property-children/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-property-children/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-property-validation-ignore-depmgmt/child/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-property-validation-ignore-depmgmt/child/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-property-validation-ignore-depmgmt/invoker.properties
+++ b/integration-test/src/it/remote-dependency-management-property-validation-ignore-depmgmt/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-property-validation-ignore-depmgmt/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-property-validation-ignore-depmgmt/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-property-validation-ignore-depmgmt/test.properties
+++ b/integration-test/src/it/remote-dependency-management-property-validation-ignore-depmgmt/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-property-validation-ignore-depmgmt/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-property-validation-ignore-depmgmt/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-property-validation-revert/child/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-property-validation-revert/child/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-property-validation-revert/invoker.properties
+++ b/integration-test/src/it/remote-dependency-management-property-validation-revert/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-property-validation-revert/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-property-validation-revert/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-property-validation-revert/test.properties
+++ b/integration-test/src/it/remote-dependency-management-property-validation-revert/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-property-validation-revert/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-property-validation-revert/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-property-validation/child/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-property-validation/child/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-property-validation/invoker.properties
+++ b/integration-test/src/it/remote-dependency-management-property-validation/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-property-validation/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-property-validation/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-property-validation/test.properties
+++ b/integration-test/src/it/remote-dependency-management-property-validation/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-property-validation/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-property-validation/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-property/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-property/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-property/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-property/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-property/test.properties
+++ b/integration-test/src/it/remote-dependency-management-property/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-dependency-management-property/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-property/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-version-range-property-substitution/invoker.properties
+++ b/integration-test/src/it/remote-dependency-management-version-range-property-substitution/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-version-range-property-substitution/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-version-range-property-substitution/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-version-range-property-substitution/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-version-range-property-substitution/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-version-range-property-substitution/test.properties
+++ b/integration-test/src/it/remote-dependency-management-version-range-property-substitution/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-version-range-property-substitution/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-version-range-property-substitution/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-version-range/invoker.properties
+++ b/integration-test/src/it/remote-dependency-management-version-range/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-version-range/pom.xml
+++ b/integration-test/src/it/remote-dependency-management-version-range/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-version-range/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-dependency-management-version-range/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-version-range/test.properties
+++ b/integration-test/src/it/remote-dependency-management-version-range/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-dependency-management-version-range/verify.groovy
+++ b/integration-test/src/it/remote-dependency-management-version-range/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-basic/pom.xml
+++ b/integration-test/src/it/remote-plugin-management-basic/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-basic/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-plugin-management-basic/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-basic/test.properties
+++ b/integration-test/src/it/remote-plugin-management-basic/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of maven compiler plugin
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-plugin-management-basic/verify.groovy
+++ b/integration-test/src/it/remote-plugin-management-basic/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-config-inject-remote-with-properties/pom.xml
+++ b/integration-test/src/it/remote-plugin-management-config-inject-remote-with-properties/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-config-inject-remote-with-properties/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-plugin-management-config-inject-remote-with-properties/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-config-inject-remote-with-properties/test.properties
+++ b/integration-test/src/it/remote-plugin-management-config-inject-remote-with-properties/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of maven compiler plugin
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-plugin-management-config-inject-remote-with-properties/verify.groovy
+++ b/integration-test/src/it/remote-plugin-management-config-inject-remote-with-properties/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-config-inject-remote/pom.xml
+++ b/integration-test/src/it/remote-plugin-management-config-inject-remote/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-config-inject-remote/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-plugin-management-config-inject-remote/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-config-inject-remote/test.properties
+++ b/integration-test/src/it/remote-plugin-management-config-inject-remote/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of maven compiler plugin
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-plugin-management-config-inject-remote/verify.groovy
+++ b/integration-test/src/it/remote-plugin-management-config-inject-remote/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-config-inject-system-property/pom.xml
+++ b/integration-test/src/it/remote-plugin-management-config-inject-system-property/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-config-inject-system-property/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-plugin-management-config-inject-system-property/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-config-inject-system-property/test.properties
+++ b/integration-test/src/it/remote-plugin-management-config-inject-system-property/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of maven compiler plugin
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-plugin-management-config-inject-system-property/verify.groovy
+++ b/integration-test/src/it/remote-plugin-management-config-inject-system-property/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-config-local-precedence/pom.xml
+++ b/integration-test/src/it/remote-plugin-management-config-local-precedence/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-config-local-precedence/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-plugin-management-config-local-precedence/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-config-local-precedence/test.properties
+++ b/integration-test/src/it/remote-plugin-management-config-local-precedence/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of maven compiler plugin
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-plugin-management-config-local-precedence/verify.groovy
+++ b/integration-test/src/it/remote-plugin-management-config-local-precedence/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-config-remote-precedence/pom.xml
+++ b/integration-test/src/it/remote-plugin-management-config-remote-precedence/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-config-remote-precedence/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-plugin-management-config-remote-precedence/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-config-remote-precedence/test.properties
+++ b/integration-test/src/it/remote-plugin-management-config-remote-precedence/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of maven compiler plugin
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-plugin-management-config-remote-precedence/verify.groovy
+++ b/integration-test/src/it/remote-plugin-management-config-remote-precedence/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-dependency/pom.xml
+++ b/integration-test/src/it/remote-plugin-management-dependency/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-dependency/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-plugin-management-dependency/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-dependency/test.properties
+++ b/integration-test/src/it/remote-plugin-management-dependency/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of maven compiler plugin
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-plugin-management-dependency/verify.groovy
+++ b/integration-test/src/it/remote-plugin-management-dependency/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-empty-config-inject-remote/pom.xml
+++ b/integration-test/src/it/remote-plugin-management-empty-config-inject-remote/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-empty-config-inject-remote/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-plugin-management-empty-config-inject-remote/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-empty-config-inject-remote/test.properties
+++ b/integration-test/src/it/remote-plugin-management-empty-config-inject-remote/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of maven compiler plugin
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-plugin-management-empty-config-inject-remote/verify.groovy
+++ b/integration-test/src/it/remote-plugin-management-empty-config-inject-remote/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-executions-bad/pom.xml
+++ b/integration-test/src/it/remote-plugin-management-executions-bad/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-executions-bad/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-plugin-management-executions-bad/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-executions-bad/test.properties
+++ b/integration-test/src/it/remote-plugin-management-executions-bad/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of maven compiler plugin
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-plugin-management-executions-bad/verify.groovy
+++ b/integration-test/src/it/remote-plugin-management-executions-bad/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-executions/pom.xml
+++ b/integration-test/src/it/remote-plugin-management-executions/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-executions/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-plugin-management-executions/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-executions/test.properties
+++ b/integration-test/src/it/remote-plugin-management-executions/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of maven compiler plugin
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-plugin-management-executions/verify.groovy
+++ b/integration-test/src/it/remote-plugin-management-executions/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-invalid-pluginmgt/pom.xml
+++ b/integration-test/src/it/remote-plugin-management-invalid-pluginmgt/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-invalid-pluginmgt/test.properties
+++ b/integration-test/src/it/remote-plugin-management-invalid-pluginmgt/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of maven compiler plugin
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-plugin-management-invalid-pluginmgt/verify.groovy
+++ b/integration-test/src/it/remote-plugin-management-invalid-pluginmgt/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-invalid/invoker.properties
+++ b/integration-test/src/it/remote-plugin-management-invalid/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-invalid/pom.xml
+++ b/integration-test/src/it/remote-plugin-management-invalid/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-invalid/test.properties
+++ b/integration-test/src/it/remote-plugin-management-invalid/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of maven compiler plugin
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-plugin-management-invalid/verify.groovy
+++ b/integration-test/src/it/remote-plugin-management-invalid/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-multiple/pom.xml
+++ b/integration-test/src/it/remote-plugin-management-multiple/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-multiple/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-plugin-management-multiple/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-multiple/test.properties
+++ b/integration-test/src/it/remote-plugin-management-multiple/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of maven compiler plugin
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-plugin-management-multiple/verify.groovy
+++ b/integration-test/src/it/remote-plugin-management-multiple/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-nonstrict/invoker.properties
+++ b/integration-test/src/it/remote-plugin-management-nonstrict/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-nonstrict/pom.xml
+++ b/integration-test/src/it/remote-plugin-management-nonstrict/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-nonstrict/test.properties
+++ b/integration-test/src/it/remote-plugin-management-nonstrict/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of maven compiler plugin
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-plugin-management-nonstrict/verify.groovy
+++ b/integration-test/src/it/remote-plugin-management-nonstrict/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-plugins/pom.xml
+++ b/integration-test/src/it/remote-plugin-management-plugins/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-plugins/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-plugin-management-plugins/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-plugins/test.properties
+++ b/integration-test/src/it/remote-plugin-management-plugins/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of maven compiler plugin
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-plugin-management-plugins/verify.groovy
+++ b/integration-test/src/it/remote-plugin-management-plugins/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-properties/pom.xml
+++ b/integration-test/src/it/remote-plugin-management-properties/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-properties/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-plugin-management-properties/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-properties/test.properties
+++ b/integration-test/src/it/remote-plugin-management-properties/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of maven compiler plugin
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-plugin-management-properties/verify.groovy
+++ b/integration-test/src/it/remote-plugin-management-properties/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-property/pom.xml
+++ b/integration-test/src/it/remote-plugin-management-property/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-property/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-plugin-management-property/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-property/test.properties
+++ b/integration-test/src/it/remote-plugin-management-property/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of maven compiler plugin
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-plugin-management-property/verify.groovy
+++ b/integration-test/src/it/remote-plugin-management-property/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-strict-fails/invoker.properties
+++ b/integration-test/src/it/remote-plugin-management-strict-fails/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-strict-fails/pom.xml
+++ b/integration-test/src/it/remote-plugin-management-strict-fails/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-strict-fails/test.properties
+++ b/integration-test/src/it/remote-plugin-management-strict-fails/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of maven compiler plugin
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-plugin-management-strict-suffix/invoker.properties
+++ b/integration-test/src/it/remote-plugin-management-strict-suffix/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-strict-suffix/pom.xml
+++ b/integration-test/src/it/remote-plugin-management-strict-suffix/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-strict-suffix/test.properties
+++ b/integration-test/src/it/remote-plugin-management-strict-suffix/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of maven compiler plugin
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-plugin-management-strict-suffix/verify.groovy
+++ b/integration-test/src/it/remote-plugin-management-strict-suffix/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-strict/invoker.properties
+++ b/integration-test/src/it/remote-plugin-management-strict/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-strict/pom.xml
+++ b/integration-test/src/it/remote-plugin-management-strict/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-strict/test.properties
+++ b/integration-test/src/it/remote-plugin-management-strict/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of maven compiler plugin
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-plugin-management-strict/verify.groovy
+++ b/integration-test/src/it/remote-plugin-management-strict/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-transitive/pom.xml
+++ b/integration-test/src/it/remote-plugin-management-transitive/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-transitive/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-plugin-management-transitive/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-transitive/test.properties
+++ b/integration-test/src/it/remote-plugin-management-transitive/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of maven compiler plugin
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-plugin-management-transitive/verify.groovy
+++ b/integration-test/src/it/remote-plugin-management-transitive/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-wildfly/pom.xml
+++ b/integration-test/src/it/remote-plugin-management-wildfly/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-wildfly/src/main/java/test/HelloWorldwithJUnit.java
+++ b/integration-test/src/it/remote-plugin-management-wildfly/src/main/java/test/HelloWorldwithJUnit.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/remote-plugin-management-wildfly/test.properties
+++ b/integration-test/src/it/remote-plugin-management-wildfly/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of maven compiler plugin
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/remote-plugin-management-wildfly/verify.groovy
+++ b/integration-test/src/it/remote-plugin-management-wildfly/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repo-removal-new-property/invoker.properties
+++ b/integration-test/src/it/repo-removal-new-property/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repo-removal-new-property/pom.xml
+++ b/integration-test/src/it/repo-removal-new-property/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repo-removal-new-property/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/repo-removal-new-property/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repo-removal-new-property/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/repo-removal-new-property/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repo-removal-new-property/test.properties
+++ b/integration-test/src/it/repo-removal-new-property/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repo-removal-new-property/verify.groovy
+++ b/integration-test/src/it/repo-removal-new-property/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repo-removal-property-substitution/child/pom.xml
+++ b/integration-test/src/it/repo-removal-property-substitution/child/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repo-removal-property-substitution/invoker.properties
+++ b/integration-test/src/it/repo-removal-property-substitution/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repo-removal-property-substitution/pom.xml
+++ b/integration-test/src/it/repo-removal-property-substitution/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repo-removal-property-substitution/test.properties
+++ b/integration-test/src/it/repo-removal-property-substitution/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repo-removal-property-substitution/verify.groovy
+++ b/integration-test/src/it/repo-removal-property-substitution/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repo-removal-withlocal/invoker.properties
+++ b/integration-test/src/it/repo-removal-withlocal/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repo-removal-withlocal/pom.xml
+++ b/integration-test/src/it/repo-removal-withlocal/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repo-removal-withlocal/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/repo-removal-withlocal/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repo-removal-withlocal/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/repo-removal-withlocal/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repo-removal-withlocal/test.properties
+++ b/integration-test/src/it/repo-removal-withlocal/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repo-removal-withlocal/verify.groovy
+++ b/integration-test/src/it/repo-removal-withlocal/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repo-removal/invoker.properties
+++ b/integration-test/src/it/repo-removal/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repo-removal/pom.xml
+++ b/integration-test/src/it/repo-removal/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repo-removal/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/repo-removal/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repo-removal/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/repo-removal/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repo-removal/test.properties
+++ b/integration-test/src/it/repo-removal/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repo-removal/verify.groovy
+++ b/integration-test/src/it/repo-removal/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repository-injection-after-removal/pom.xml
+++ b/integration-test/src/it/repository-injection-after-removal/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repository-injection-after-removal/test.properties
+++ b/integration-test/src/it/repository-injection-after-removal/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the repositories
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/repository-injection-after-removal/verify.groovy
+++ b/integration-test/src/it/repository-injection-after-removal/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repository-injection-basic/pom.xml
+++ b/integration-test/src/it/repository-injection-basic/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repository-injection-basic/test.properties
+++ b/integration-test/src/it/repository-injection-basic/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the repositories
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/repository-injection-basic/verify.groovy
+++ b/integration-test/src/it/repository-injection-basic/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repository-injection-child/child/pom.xml
+++ b/integration-test/src/it/repository-injection-child/child/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repository-injection-child/pom.xml
+++ b/integration-test/src/it/repository-injection-child/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repository-injection-child/test.properties
+++ b/integration-test/src/it/repository-injection-child/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/repository-injection-child/verify.groovy
+++ b/integration-test/src/it/repository-injection-child/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repository-injection-wildcard/child/pom.xml
+++ b/integration-test/src/it/repository-injection-wildcard/child/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repository-injection-wildcard/pom.xml
+++ b/integration-test/src/it/repository-injection-wildcard/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/repository-injection-wildcard/test.properties
+++ b/integration-test/src/it/repository-injection-wildcard/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 # Override the version of JUnit
 # The colon needs to be escaped to prevent the invoker plugin from misinterpreting it

--- a/integration-test/src/it/repository-injection-wildcard/verify.groovy
+++ b/integration-test/src/it/repository-injection-wildcard/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-dependency-version-manip-child-module/child/pom.xml
+++ b/integration-test/src/it/rest-dependency-version-manip-child-module/child/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-dependency-version-manip-child-module/invoker.properties
+++ b/integration-test/src/it/rest-dependency-version-manip-child-module/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-dependency-version-manip-child-module/pom.xml
+++ b/integration-test/src/it/rest-dependency-version-manip-child-module/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-dependency-version-manip-child-module/settings.xml
+++ b/integration-test/src/it/rest-dependency-version-manip-child-module/settings.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-dependency-version-manip-child-module/test.properties
+++ b/integration-test/src/it/rest-dependency-version-manip-child-module/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-dependency-version-manip-child-module/verify.groovy
+++ b/integration-test/src/it/rest-dependency-version-manip-child-module/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-dependency-version-manip-profile/invoker.properties
+++ b/integration-test/src/it/rest-dependency-version-manip-profile/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-dependency-version-manip-profile/pom.xml
+++ b/integration-test/src/it/rest-dependency-version-manip-profile/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-dependency-version-manip-profile/settings.xml
+++ b/integration-test/src/it/rest-dependency-version-manip-profile/settings.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-dependency-version-manip-profile/test.properties
+++ b/integration-test/src/it/rest-dependency-version-manip-profile/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-dependency-version-manip-profile/verify.groovy
+++ b/integration-test/src/it/rest-dependency-version-manip-profile/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-headers/invoker.properties
+++ b/integration-test/src/it/rest-headers/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-headers/pom.xml
+++ b/integration-test/src/it/rest-headers/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-headers/test.properties
+++ b/integration-test/src/it/rest-headers/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-headers/verify.groovy
+++ b/integration-test/src/it/rest-headers/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-override-transitive-dependency-management/child1/pom.xml
+++ b/integration-test/src/it/rest-override-transitive-dependency-management/child1/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-override-transitive-dependency-management/child1/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/rest-override-transitive-dependency-management/child1/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-override-transitive-dependency-management/child1/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/rest-override-transitive-dependency-management/child1/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-override-transitive-dependency-management/child2/pom.xml
+++ b/integration-test/src/it/rest-override-transitive-dependency-management/child2/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-override-transitive-dependency-management/child2/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/rest-override-transitive-dependency-management/child2/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-override-transitive-dependency-management/child2/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/rest-override-transitive-dependency-management/child2/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-override-transitive-dependency-management/invoker.properties
+++ b/integration-test/src/it/rest-override-transitive-dependency-management/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-override-transitive-dependency-management/pom.xml
+++ b/integration-test/src/it/rest-override-transitive-dependency-management/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-override-transitive-dependency-management/settings.xml
+++ b/integration-test/src/it/rest-override-transitive-dependency-management/settings.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-override-transitive-dependency-management/test.properties
+++ b/integration-test/src/it/rest-override-transitive-dependency-management/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-override-transitive-dependency-management/verify.groovy
+++ b/integration-test/src/it/rest-override-transitive-dependency-management/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-alignment-disabled/invoker.properties
+++ b/integration-test/src/it/rest-version-manip-alignment-disabled/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-alignment-disabled/pom.xml
+++ b/integration-test/src/it/rest-version-manip-alignment-disabled/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-alignment-disabled/test.properties
+++ b/integration-test/src/it/rest-version-manip-alignment-disabled/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-alignment-disabled/verify.groovy
+++ b/integration-test/src/it/rest-version-manip-alignment-disabled/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-bomrest/invoker.properties
+++ b/integration-test/src/it/rest-version-manip-bomrest/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-bomrest/pom.xml
+++ b/integration-test/src/it/rest-version-manip-bomrest/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-bomrest/test.properties
+++ b/integration-test/src/it/rest-version-manip-bomrest/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-bomrest/verify.groovy
+++ b/integration-test/src/it/rest-version-manip-bomrest/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-mixed-suffix-orig-rh-norhalign/invoker.properties
+++ b/integration-test/src/it/rest-version-manip-mixed-suffix-orig-rh-norhalign/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-mixed-suffix-orig-rh-norhalign/pom.xml
+++ b/integration-test/src/it/rest-version-manip-mixed-suffix-orig-rh-norhalign/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-mixed-suffix-orig-rh-norhalign/test.properties
+++ b/integration-test/src/it/rest-version-manip-mixed-suffix-orig-rh-norhalign/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-mixed-suffix-orig-rh-norhalign/verify.groovy
+++ b/integration-test/src/it/rest-version-manip-mixed-suffix-orig-rh-norhalign/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-mixed-suffix-orig-rh/invoker.properties
+++ b/integration-test/src/it/rest-version-manip-mixed-suffix-orig-rh/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-mixed-suffix-orig-rh/pom.xml
+++ b/integration-test/src/it/rest-version-manip-mixed-suffix-orig-rh/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-mixed-suffix-orig-rh/test.properties
+++ b/integration-test/src/it/rest-version-manip-mixed-suffix-orig-rh/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-mixed-suffix-orig-rh/verify.groovy
+++ b/integration-test/src/it/rest-version-manip-mixed-suffix-orig-rh/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-mixed-suffix-timestamp/invoker.properties
+++ b/integration-test/src/it/rest-version-manip-mixed-suffix-timestamp/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-mixed-suffix-timestamp/pom.xml
+++ b/integration-test/src/it/rest-version-manip-mixed-suffix-timestamp/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-mixed-suffix-timestamp/test.properties
+++ b/integration-test/src/it/rest-version-manip-mixed-suffix-timestamp/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-mixed-suffix-timestamp/verify.groovy
+++ b/integration-test/src/it/rest-version-manip-mixed-suffix-timestamp/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-mixed-suffix/invoker.properties
+++ b/integration-test/src/it/rest-version-manip-mixed-suffix/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-mixed-suffix/pom.xml
+++ b/integration-test/src/it/rest-version-manip-mixed-suffix/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-mixed-suffix/test.properties
+++ b/integration-test/src/it/rest-version-manip-mixed-suffix/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-mixed-suffix/verify.groovy
+++ b/integration-test/src/it/rest-version-manip-mixed-suffix/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-only-override/invoker.properties
+++ b/integration-test/src/it/rest-version-manip-only-override/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-only-override/pom.xml
+++ b/integration-test/src/it/rest-version-manip-only-override/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-only-override/test.properties
+++ b/integration-test/src/it/rest-version-manip-only-override/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-only-override/verify.groovy
+++ b/integration-test/src/it/rest-version-manip-only-override/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-only-relocate/invoker.properties
+++ b/integration-test/src/it/rest-version-manip-only-relocate/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-only-relocate/pom.xml
+++ b/integration-test/src/it/rest-version-manip-only-relocate/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-only-relocate/test.properties
+++ b/integration-test/src/it/rest-version-manip-only-relocate/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-only-relocate/verify.groovy
+++ b/integration-test/src/it/rest-version-manip-only-relocate/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-only/invoker.properties
+++ b/integration-test/src/it/rest-version-manip-only/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-only/pom.xml
+++ b/integration-test/src/it/rest-version-manip-only/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-only/test.properties
+++ b/integration-test/src/it/rest-version-manip-only/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-only/verify.groovy
+++ b/integration-test/src/it/rest-version-manip-only/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-plugin-bomrest/invoker.properties
+++ b/integration-test/src/it/rest-version-manip-plugin-bomrest/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-plugin-bomrest/pom.xml
+++ b/integration-test/src/it/rest-version-manip-plugin-bomrest/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-plugin-bomrest/test.properties
+++ b/integration-test/src/it/rest-version-manip-plugin-bomrest/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-plugin-bomrest/verify.groovy
+++ b/integration-test/src/it/rest-version-manip-plugin-bomrest/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-plugin-rest/invoker.properties
+++ b/integration-test/src/it/rest-version-manip-plugin-rest/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-plugin-rest/pom.xml
+++ b/integration-test/src/it/rest-version-manip-plugin-rest/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-plugin-rest/test.properties
+++ b/integration-test/src/it/rest-version-manip-plugin-rest/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-plugin-rest/verify.groovy
+++ b/integration-test/src/it/rest-version-manip-plugin-rest/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-plugin-restbom/invoker.properties
+++ b/integration-test/src/it/rest-version-manip-plugin-restbom/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-plugin-restbom/pom.xml
+++ b/integration-test/src/it/rest-version-manip-plugin-restbom/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-plugin-restbom/test.properties
+++ b/integration-test/src/it/rest-version-manip-plugin-restbom/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-plugin-restbom/verify.groovy
+++ b/integration-test/src/it/rest-version-manip-plugin-restbom/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-restbom-autodetectbom/invoker.properties
+++ b/integration-test/src/it/rest-version-manip-restbom-autodetectbom/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-restbom-autodetectbom/pom.xml
+++ b/integration-test/src/it/rest-version-manip-restbom-autodetectbom/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-restbom-autodetectbom/test.properties
+++ b/integration-test/src/it/rest-version-manip-restbom-autodetectbom/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-restbom-autodetectbom/verify.groovy
+++ b/integration-test/src/it/rest-version-manip-restbom-autodetectbom/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-restbom/invoker.properties
+++ b/integration-test/src/it/rest-version-manip-restbom/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-restbom/pom.xml
+++ b/integration-test/src/it/rest-version-manip-restbom/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-restbom/test.properties
+++ b/integration-test/src/it/rest-version-manip-restbom/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-restbom/verify.groovy
+++ b/integration-test/src/it/rest-version-manip-restbom/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-snapshot/invoker.properties
+++ b/integration-test/src/it/rest-version-manip-snapshot/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-snapshot/pom.xml
+++ b/integration-test/src/it/rest-version-manip-snapshot/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-snapshot/test.properties
+++ b/integration-test/src/it/rest-version-manip-snapshot/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-snapshot/verify.groovy
+++ b/integration-test/src/it/rest-version-manip-snapshot/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-suffix-strip-increment/invoker.properties
+++ b/integration-test/src/it/rest-version-manip-suffix-strip-increment/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-suffix-strip-increment/pom.xml
+++ b/integration-test/src/it/rest-version-manip-suffix-strip-increment/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-suffix-strip-increment/test.properties
+++ b/integration-test/src/it/rest-version-manip-suffix-strip-increment/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/rest-version-manip-suffix-strip-increment/verify.groovy
+++ b/integration-test/src/it/rest-version-manip-suffix-strip-increment/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/settings.xml
+++ b/integration-test/src/it/settings.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/depMgmt1/Sample.groovy
+++ b/integration-test/src/it/setup/depMgmt1/Sample.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/depMgmt1/invoker.properties
+++ b/integration-test/src/it/setup/depMgmt1/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/depMgmt1/pom.xml
+++ b/integration-test/src/it/setup/depMgmt1/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/depMgmt2/POMModifier.groovy
+++ b/integration-test/src/it/setup/depMgmt2/POMModifier.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/depMgmt2/invoker.properties
+++ b/integration-test/src/it/setup/depMgmt2/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/depMgmt2/pom.xml
+++ b/integration-test/src/it/setup/depMgmt2/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/depMgmt3/Sample.groovy
+++ b/integration-test/src/it/setup/depMgmt3/Sample.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/depMgmt3/invoker.properties
+++ b/integration-test/src/it/setup/depMgmt3/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/depMgmt3/pom.xml
+++ b/integration-test/src/it/setup/depMgmt3/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/depMgmt4/invoker.properties
+++ b/integration-test/src/it/setup/depMgmt4/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/depMgmt4/pom.xml
+++ b/integration-test/src/it/setup/depMgmt4/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/pluginMgmt1/invoker.properties
+++ b/integration-test/src/it/setup/pluginMgmt1/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/pluginMgmt1/pom.xml
+++ b/integration-test/src/it/setup/pluginMgmt1/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/pluginMgmt2/invoker.properties
+++ b/integration-test/src/it/setup/pluginMgmt2/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/pluginMgmt2/pom.xml
+++ b/integration-test/src/it/setup/pluginMgmt2/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/pluginMgmt3/invoker.properties
+++ b/integration-test/src/it/setup/pluginMgmt3/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/pluginMgmt3/pom.xml
+++ b/integration-test/src/it/setup/pluginMgmt3/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/profileMgmt1/invoker.properties
+++ b/integration-test/src/it/setup/profileMgmt1/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/profileMgmt1/pom.xml
+++ b/integration-test/src/it/setup/profileMgmt1/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/propertyMgmt1/invoker.properties
+++ b/integration-test/src/it/setup/propertyMgmt1/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/propertyMgmt1/pom.xml
+++ b/integration-test/src/it/setup/propertyMgmt1/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/repoMgmt1/invoker.properties
+++ b/integration-test/src/it/setup/repoMgmt1/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/repoMgmt1/pom.xml
+++ b/integration-test/src/it/setup/repoMgmt1/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/simpleParent/invoker.properties
+++ b/integration-test/src/it/setup/simpleParent/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/setup/simpleParent/pom.xml
+++ b/integration-test/src/it/setup/simpleParent/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-alphanumeric/invoker.properties
+++ b/integration-test/src/it/simple-alphanumeric/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-alphanumeric/pom.xml
+++ b/integration-test/src/it/simple-alphanumeric/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-alphanumeric/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/simple-alphanumeric/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-alphanumeric/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/simple-alphanumeric/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-alphanumeric/test.properties
+++ b/integration-test/src/it/simple-alphanumeric/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-alphanumeric/verify.groovy
+++ b/integration-test/src/it/simple-alphanumeric/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-directory-path-inverse/invoker.properties
+++ b/integration-test/src/it/simple-numeric-directory-path-inverse/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-directory-path-inverse/parent/pom.xml
+++ b/integration-test/src/it/simple-numeric-directory-path-inverse/parent/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-directory-path-inverse/pom.xml
+++ b/integration-test/src/it/simple-numeric-directory-path-inverse/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-directory-path-inverse/test.properties
+++ b/integration-test/src/it/simple-numeric-directory-path-inverse/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-directory-path-inverse/verify.groovy
+++ b/integration-test/src/it/simple-numeric-directory-path-inverse/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-directory-path/child/pom.xml
+++ b/integration-test/src/it/simple-numeric-directory-path/child/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-directory-path/parent/invoker.properties
+++ b/integration-test/src/it/simple-numeric-directory-path/parent/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-directory-path/parent/pom.xml
+++ b/integration-test/src/it/simple-numeric-directory-path/parent/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-directory-path/parent/test.properties
+++ b/integration-test/src/it/simple-numeric-directory-path/parent/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-directory-path/parent/verify.groovy
+++ b/integration-test/src/it/simple-numeric-directory-path/parent/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-issue221/invoker.properties
+++ b/integration-test/src/it/simple-numeric-issue221/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-issue221/pom.xml
+++ b/integration-test/src/it/simple-numeric-issue221/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-issue221/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/simple-numeric-issue221/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-issue221/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/simple-numeric-issue221/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-issue221/test.properties
+++ b/integration-test/src/it/simple-numeric-issue221/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-issue221/verify.groovy
+++ b/integration-test/src/it/simple-numeric-issue221/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-override-nosuffix/invoker.properties
+++ b/integration-test/src/it/simple-numeric-override-nosuffix/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-override-nosuffix/pom.xml
+++ b/integration-test/src/it/simple-numeric-override-nosuffix/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-override-nosuffix/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/simple-numeric-override-nosuffix/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-override-nosuffix/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/simple-numeric-override-nosuffix/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-override-nosuffix/test.properties
+++ b/integration-test/src/it/simple-numeric-override-nosuffix/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-override-nosuffix/verify.groovy
+++ b/integration-test/src/it/simple-numeric-override-nosuffix/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-override/invoker.properties
+++ b/integration-test/src/it/simple-numeric-override/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-override/pom.xml
+++ b/integration-test/src/it/simple-numeric-override/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-override/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/simple-numeric-override/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-override/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/simple-numeric-override/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-override/test.properties
+++ b/integration-test/src/it/simple-numeric-override/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-override/verify.groovy
+++ b/integration-test/src/it/simple-numeric-override/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-properties/child/pom.xml
+++ b/integration-test/src/it/simple-numeric-properties/child/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-properties/invoker.properties
+++ b/integration-test/src/it/simple-numeric-properties/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-properties/pom.xml
+++ b/integration-test/src/it/simple-numeric-properties/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-properties/test.properties
+++ b/integration-test/src/it/simple-numeric-properties/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-properties/verify.groovy
+++ b/integration-test/src/it/simple-numeric-properties/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-with-antxmlns/invoker.properties
+++ b/integration-test/src/it/simple-numeric-with-antxmlns/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-with-antxmlns/pom.xml
+++ b/integration-test/src/it/simple-numeric-with-antxmlns/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-with-antxmlns/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/simple-numeric-with-antxmlns/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-with-antxmlns/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/simple-numeric-with-antxmlns/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-with-antxmlns/test.properties
+++ b/integration-test/src/it/simple-numeric-with-antxmlns/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-with-antxmlns/verify.groovy
+++ b/integration-test/src/it/simple-numeric-with-antxmlns/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-with-prefix/invoker.properties
+++ b/integration-test/src/it/simple-numeric-with-prefix/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-with-prefix/pom.xml
+++ b/integration-test/src/it/simple-numeric-with-prefix/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-with-prefix/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/simple-numeric-with-prefix/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-with-prefix/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/simple-numeric-with-prefix/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-with-prefix/test.properties
+++ b/integration-test/src/it/simple-numeric-with-prefix/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric-with-prefix/verify.groovy
+++ b/integration-test/src/it/simple-numeric-with-prefix/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric/invoker.properties
+++ b/integration-test/src/it/simple-numeric/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric/pom.xml
+++ b/integration-test/src/it/simple-numeric/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/simple-numeric/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/simple-numeric/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric/test.properties
+++ b/integration-test/src/it/simple-numeric/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/simple-numeric/verify.groovy
+++ b/integration-test/src/it/simple-numeric/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/single-module-bom-generation/invoker.properties
+++ b/integration-test/src/it/single-module-bom-generation/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/single-module-bom-generation/pom.xml
+++ b/integration-test/src/it/single-module-bom-generation/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/single-module-bom-generation/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/single-module-bom-generation/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/single-module-bom-generation/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/single-module-bom-generation/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/single-module-bom-generation/test.properties
+++ b/integration-test/src/it/single-module-bom-generation/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/single-module-bom-generation/verify.groovy
+++ b/integration-test/src/it/single-module-bom-generation/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/xml-json-modify/activemq-artemis-dep.xml
+++ b/integration-test/src/it/xml-json-modify/activemq-artemis-dep.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/xml-json-modify/invoker.properties
+++ b/integration-test/src/it/xml-json-modify/invoker.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/xml-json-modify/pom.xml
+++ b/integration-test/src/it/xml-json-modify/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/xml-json-modify/setup.groovy
+++ b/integration-test/src/it/xml-json-modify/setup.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/xml-json-modify/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
+++ b/integration-test/src/it/xml-json-modify/src/main/java/org/jboss/pnc/mavenmanipulator/versioning/test/App.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/xml-json-modify/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
+++ b/integration-test/src/it/xml-json-modify/src/test/java/org/jboss/pnc/mavenmanipulator/versioning/test/AppTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/xml-json-modify/test.properties
+++ b/integration-test/src/it/xml-json-modify/test.properties
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/it/xml-json-modify/verify.groovy
+++ b/integration-test/src/it/xml-json-modify/verify.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/main/java/org/jboss/pnc/mavenmanipulator/integrationtest/ITestUtils.java
+++ b/integration-test/src/main/java/org/jboss/pnc/mavenmanipulator/integrationtest/ITestUtils.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/main/java/org/jboss/pnc/mavenmanipulator/integrationtest/invoker/DefaultExecutionParser.java
+++ b/integration-test/src/main/java/org/jboss/pnc/mavenmanipulator/integrationtest/invoker/DefaultExecutionParser.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/main/java/org/jboss/pnc/mavenmanipulator/integrationtest/invoker/Execution.java
+++ b/integration-test/src/main/java/org/jboss/pnc/mavenmanipulator/integrationtest/invoker/Execution.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/main/java/org/jboss/pnc/mavenmanipulator/integrationtest/invoker/ExecutionParser.java
+++ b/integration-test/src/main/java/org/jboss/pnc/mavenmanipulator/integrationtest/invoker/ExecutionParser.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/main/java/org/jboss/pnc/mavenmanipulator/integrationtest/invoker/ExecutionParserHandler.java
+++ b/integration-test/src/main/java/org/jboss/pnc/mavenmanipulator/integrationtest/invoker/ExecutionParserHandler.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/test/java/org/jboss/pnc/mavenmanipulator/integrationtest/CheckStandardMavenTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/mavenmanipulator/integrationtest/CheckStandardMavenTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/test/java/org/jboss/pnc/mavenmanipulator/integrationtest/CircularIntegrationTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/mavenmanipulator/integrationtest/CircularIntegrationTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/test/java/org/jboss/pnc/mavenmanipulator/integrationtest/DefaultCliIntegrationTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/mavenmanipulator/integrationtest/DefaultCliIntegrationTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/test/java/org/jboss/pnc/mavenmanipulator/integrationtest/DefaultCliIntegrationTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/mavenmanipulator/integrationtest/DefaultCliIntegrationTest.java
@@ -92,7 +92,8 @@ public class DefaultCliIntegrationTest {
         boolean result = false;
         File t1 = new File(
                 DEFAULT_MVN_PARAMS.get("maven.repo.local"),
-                "org" + File.separator + "commonjava" + File.separator + "maven" + File.separator + "ext");
+                "org" + File.separator + "jboss" + File.separator + "pnc" + File.separator + "maven-manipulator"
+                        + File.separator + "integration-test");
         if (t1.exists()) {
             File t2 = new File(t1, test.getName());
             File[] directories = t2.listFiles(File::isDirectory);

--- a/integration-test/src/test/java/org/jboss/pnc/mavenmanipulator/integrationtest/GroovyIntegrationTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/mavenmanipulator/integrationtest/GroovyIntegrationTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/test/java/org/jboss/pnc/mavenmanipulator/integrationtest/RESTIntegrationTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/mavenmanipulator/integrationtest/RESTIntegrationTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/test/java/org/jboss/pnc/mavenmanipulator/integrationtest/ResultJsonFileTest.java
+++ b/integration-test/src/test/java/org/jboss/pnc/mavenmanipulator/integrationtest/ResultJsonFileTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integration-test/src/test/resources/result-json-test/pom.xml
+++ b/integration-test/src/test/resources/result-json-test/pom.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/pom.xml
+++ b/io/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/ConfigIO.java
+++ b/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/ConfigIO.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/FileIO.java
+++ b/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/FileIO.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/JSONIO.java
+++ b/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/JSONIO.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/ModelIO.java
+++ b/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/ModelIO.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/PomIO.java
+++ b/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/PomIO.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/SettingsIO.java
+++ b/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/SettingsIO.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/XMLIO.java
+++ b/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/XMLIO.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/resolver/ExtensionInfrastructure.java
+++ b/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/resolver/ExtensionInfrastructure.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/resolver/GalleyAPIWrapper.java
+++ b/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/resolver/GalleyAPIWrapper.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/resolver/GalleyInfrastructure.java
+++ b/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/resolver/GalleyInfrastructure.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/resolver/MavenLocationExpander.java
+++ b/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/resolver/MavenLocationExpander.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/rest/DefaultTranslator.java
+++ b/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/rest/DefaultTranslator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/rest/RestException.java
+++ b/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/rest/RestException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/rest/Translator.java
+++ b/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/rest/Translator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/FileIOTest.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/FileIOTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/JSONIOTest.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/JSONIOTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/ManipulationExceptionTest.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/ManipulationExceptionTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/ManipulationUncheckedExceptionTest.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/ManipulationUncheckedExceptionTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/PomIOTest.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/PomIOTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/SettingsIOTest.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/SettingsIOTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.jboss.pnc.mavenmanipulator.io;
 
 import static org.junit.Assert.assertEquals;

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/XMLIOTest.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/XMLIOTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/YamlTest.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/YamlTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/resolver/MavenLocationExpanderTest.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/resolver/MavenLocationExpanderTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/AutoSplitTest.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/AutoSplitTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/HandleServiceUnavailableTest.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/HandleServiceUnavailableTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/HttpEndpointTest.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/HttpEndpointTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/HttpErrorTranslatorTest.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/HttpErrorTranslatorTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/HttpHeaderHeaderTest.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/HttpHeaderHeaderTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/HttpMessageTranslatorTest.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/HttpMessageTranslatorTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/RESTHeaderTest.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/RESTHeaderTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/RESTParametersModeTest.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/RESTParametersModeTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/VersionTranslatorSplitTest.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/VersionTranslatorSplitTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/VersionTranslatorTest.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/VersionTranslatorTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/handler/AddSuffixJettyHandler.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/handler/AddSuffixJettyHandler.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/handler/GAVSchema.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/handler/GAVSchema.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/handler/SpyFailJettyHandler.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/handler/SpyFailJettyHandler.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/handler/StaticResourceHandler.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/handler/StaticResourceHandler.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/rule/MockServer.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/rest/rule/MockServer.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/server/HttpServer.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/server/HttpServer.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/server/JettyHttpServer.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/server/JettyHttpServer.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/server/exception/ServerInternalException.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/server/exception/ServerInternalException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/server/exception/ServerSetupException.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/server/exception/ServerSetupException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2012 Red Hat, Inc.
+ * Copyright © 2012 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/resources/logback-test.xml
+++ b/io/src/test/resources/logback-test.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/resources/org/jboss/pnc/mavenmanipulator/io/activemq-artemis-dep.xml
+++ b/io/src/test/resources/org/jboss/pnc/mavenmanipulator/io/activemq-artemis-dep.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/resources/org/jboss/pnc/mavenmanipulator/io/azure-file-system.windup.xml
+++ b/io/src/test/resources/org/jboss/pnc/mavenmanipulator/io/azure-file-system.windup.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/resources/org/jboss/pnc/mavenmanipulator/io/pme.yaml
+++ b/io/src/test/resources/org/jboss/pnc/mavenmanipulator/io/pme.yaml
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright © 2012 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/resources/org/jboss/pnc/mavenmanipulator/io/pom.xml
+++ b/io/src/test/resources/org/jboss/pnc/mavenmanipulator/io/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/resources/org/jboss/pnc/mavenmanipulator/io/settings-wth-encoding.xml
+++ b/io/src/test/resources/org/jboss/pnc/mavenmanipulator/io/settings-wth-encoding.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/io/src/test/resources/org/jboss/pnc/mavenmanipulator/io/settings.xml
+++ b/io/src/test/resources/org/jboss/pnc/mavenmanipulator/io/settings.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2012 Red Hat, Inc.
+    Copyright © 2012 Red Hat, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
@@ -638,7 +638,7 @@
             <licenseSets>
               <licenseSet>
                 <header>com/mycila/maven/plugin/license/templates/APACHE-2-noemail.txt</header>
-                <excludes combine.children="append">
+                <excludes>
                   <exclude>**/commonjava/maven/ext/common/ExceptionHelper.java</exclude>
                   <exclude>**/src/test/resources/org.jboss.pnc.mavenmanipulator/io/pom.xml</exclude>
                   <exclude>**/src/test/resources/gavs.txt</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.redhat.rcm</groupId>
-    <artifactId>redhat-releng-tools</artifactId>
-    <version>12</version>
+    <groupId>org.jboss</groupId>
+    <artifactId>jboss-parent</artifactId>
+    <version>53</version>
   </parent>
 
   <groupId>org.jboss.pnc.maven-manipulator</groupId>
@@ -72,10 +72,18 @@
 
   <properties>
     <projectOwner>Red Hat, Inc.</projectOwner>
+    <projectEmail>ncross@redhat.com</projectEmail>
 
     <javaVersion>1.8</javaVersion>
     <javaTestVersion>${javaVersion}</javaTestVersion>
     <addJarIndex>false</addJarIndex>
+
+    <!-- Override jboss-parent compiler settings to match project requirements -->
+    <maven.compiler.source>${javaVersion}</maven.compiler.source>
+    <maven.compiler.target>${javaVersion}</maven.compiler.target>
+
+    <!-- Central publishing configuration -->
+    <central.autoPublish>false</central.autoPublish>
 
     <mavenVersion>3.9.14</mavenVersion>
     <atlasVersion>1.2.2</atlasVersion>
@@ -622,13 +630,21 @@
         <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
+          <version>5.0.0</version>
           <configuration>
-            <excludes combine.children="append">
-              <exclude>ide-config/eclipse.importorder</exclude>
-              <exclude>**/commonjava/maven/ext/common/ExceptionHelper.java</exclude>
-              <exclude>**/src/test/resources/org.jboss.pnc.mavenmanipulator/io/pom.xml</exclude>
-              <exclude>**/src/test/resources/gavs.txt</exclude>
-            </excludes>
+            <properties>
+              <owner>${projectOwner}</owner>
+            </properties>
+            <licenseSets>
+              <licenseSet>
+                <header>com/mycila/maven/plugin/license/templates/APACHE-2-noemail.txt</header>
+                <excludes combine.children="append">
+                  <exclude>**/commonjava/maven/ext/common/ExceptionHelper.java</exclude>
+                  <exclude>**/src/test/resources/org.jboss.pnc.mavenmanipulator/io/pom.xml</exclude>
+                  <exclude>**/src/test/resources/gavs.txt</exclude>
+                </excludes>
+              </licenseSet>
+            </licenseSets>
           </configuration>
         </plugin>
         <plugin>
@@ -743,6 +759,22 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-java-version</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>[11,)</version>
+                  <message>To build this project JDK 11 (or greater) is required. Please install it.</message>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -865,6 +897,41 @@
             <groupId>com.diffplug.spotless</groupId>
             <artifactId>spotless-maven-plugin</artifactId>
             <version>3.1.0</version>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>central-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.mycila</groupId>
+            <artifactId>license-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>check-license-headers</id>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+                <phase>verify</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <configuration>
+              <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,29 @@
     <!-- Override jboss-parent compiler settings to match project requirements -->
     <maven.compiler.source>${javaVersion}</maven.compiler.source>
     <maven.compiler.target>${javaVersion}</maven.compiler.target>
+    <maven.compiler.testTarget>${javaVersion}</maven.compiler.testTarget>
+    <maven.compiler.testSource>${javaVersion}</maven.compiler.testSource>
+    <maven.compiler.release>8</maven.compiler.release>
+    <maven.compiler.testRelease>8</maven.compiler.testRelease>
+
+    <!-- Override enforcer requirements -->
+    <maven.min.version>3.3.9</maven.min.version>
+    <jdk.min.version>11</jdk.min.version>
+
+    <!-- Downgrade from parent to ensure it works with all maven versions -->
+    <version.assembly.plugin>3.6.0</version.assembly.plugin>
+    <version.buildnumber.plugin>3.0.0</version.buildnumber.plugin>
+    <version.clean.plugin>3.3.2</version.clean.plugin>
+    <version.compiler.plugin>3.12.1</version.compiler.plugin>
+    <version.enforcer.plugin>3.4.1</version.enforcer.plugin>
+    <version.install.plugin>3.1.1</version.install.plugin>
+    <version.gpg.plugin>3.2.4</version.gpg.plugin>
+    <version.deploy.plugin>3.1.1</version.deploy.plugin>
+    <version.jar.plugin>3.3.0</version.jar.plugin>
+    <version.javadoc.plugin>3.6.3</version.javadoc.plugin>
+    <version.resources.plugin>3.3.1</version.resources.plugin>
+    <version.source.plugin>3.3.1</version.source.plugin>
+    <version.surefire>3.2.5</version.surefire>
 
     <!-- Central publishing configuration -->
     <central.autoPublish>false</central.autoPublish>
@@ -757,26 +780,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce-java-version</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireJavaVersion>
-                  <version>[11,)</version>
-                  <message>To build this project JDK 11 (or greater) is required. Please install it.</message>
-                </requireJavaVersion>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
         <executions>
@@ -923,7 +926,7 @@
       </build>
     </profile>
     <profile>
-      <id>release</id>
+      <id>jboss-release</id>
       <build>
         <plugins>
           <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -90,24 +90,6 @@
     <maven.min.version>3.3.9</maven.min.version>
     <jdk.min.version>11</jdk.min.version>
 
-    <!-- Downgrade from parent to ensure it works with all maven versions -->
-    <version.assembly.plugin>3.6.0</version.assembly.plugin>
-    <version.buildnumber.plugin>3.0.0</version.buildnumber.plugin>
-    <version.clean.plugin>3.3.2</version.clean.plugin>
-    <version.compiler.plugin>3.12.1</version.compiler.plugin>
-    <version.enforcer.plugin>3.4.1</version.enforcer.plugin>
-    <version.install.plugin>3.1.1</version.install.plugin>
-    <version.gpg.plugin>3.2.4</version.gpg.plugin>
-    <version.deploy.plugin>3.1.1</version.deploy.plugin>
-    <version.jar.plugin>3.3.0</version.jar.plugin>
-    <version.javadoc.plugin>3.6.3</version.javadoc.plugin>
-    <version.resources.plugin>3.3.1</version.resources.plugin>
-    <version.source.plugin>3.3.1</version.source.plugin>
-    <version.surefire>3.2.5</version.surefire>
-
-    <!-- Central publishing configuration -->
-    <central.autoPublish>false</central.autoPublish>
-
     <mavenVersion>3.9.14</mavenVersion>
     <atlasVersion>1.2.2</atlasVersion>
     <daVersion>2.6.9</daVersion>
@@ -861,6 +843,15 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>central-publisher</publishingServerId>
+          <autoPublish>false</autoPublish>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 
@@ -938,6 +929,25 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>early-maven</id>
+      <properties>
+        <!-- Downgrade from parent to ensure it works with all maven versions -->
+        <version.assembly.plugin>3.6.0</version.assembly.plugin>
+        <version.buildnumber.plugin>3.0.0</version.buildnumber.plugin>
+        <version.clean.plugin>3.3.2</version.clean.plugin>
+        <version.compiler.plugin>3.12.1</version.compiler.plugin>
+        <version.enforcer.plugin>3.4.1</version.enforcer.plugin>
+        <version.install.plugin>3.1.1</version.install.plugin>
+        <version.gpg.plugin>3.2.4</version.gpg.plugin>
+        <version.deploy.plugin>3.1.1</version.deploy.plugin>
+        <version.jar.plugin>3.3.0</version.jar.plugin>
+        <version.javadoc.plugin>3.6.3</version.javadoc.plugin>
+        <version.resources.plugin>3.3.1</version.resources.plugin>
+        <version.source.plugin>3.3.1</version.source.plugin>
+        <version.surefire>3.2.5</version.surefire>
+      </properties>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
This moves from using redhat-releng-tools parent pom to jboss-parent.

The only issue is that I have to manually downgrade the plugins in [`69daa09` (this PR)](https://github.com/project-ncl/pom-manipulation-ext/pull/1136/commits/69daa09cd82bfc57598c3e97c9e6648d114d24a8) as many require >= Maven 3.6.3. Its not possible to activate a profile based upon the version of Maven. In [`79fbe32` (this PR)](https://github.com/project-ncl/pom-manipulation-ext/pull/1136/commits/79fbe32c397e05dcd70163b1e987a23750609ba9) I've tweaked the CI so it uses a profile to downgrade the plugins for early maven versions. This will also work locally (`-Pearly-maven`).
