### PR TITLE
NCLSUP-1478 Add a suppressManifestComment option

### DIFF
--- a/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/PomIO.java
+++ b/io/src/main/java/org/jboss/pnc/mavenmanipulator/io/PomIO.java
@@ -48,6 +48,7 @@ import org.apache.maven.shared.release.transform.jdom2.JDomModelETLFactory;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.commonjava.atlas.maven.ident.ref.ProjectVersionRef;
 import org.commonjava.maven.galley.maven.parse.PomPeek;
+import org.jboss.pnc.mavenmanipulator.annotation.ConfigValue;
 import org.jboss.pnc.mavenmanipulator.common.exception.ManipulationException;
 import org.jboss.pnc.mavenmanipulator.common.jdom.JDOMModelConverter;
 import org.jboss.pnc.mavenmanipulator.common.model.Project;
@@ -69,6 +70,18 @@ public class PomIO {
     // TODO: Remove this if no side affects reported in 2022.
     public static final String PARSE_POM_TEMPLATES = "parsePomTemplates";
 
+    /**
+     * Configuration property to suppress the manifest comment that is normally added to the execution root POM.
+     * When set to {@code true}, the "Modified by POM Manipulation Extension for Maven" comment will not be
+     * added to the rewritten POM file.
+     * <p>
+     * Property name: {@value}
+     * <p>
+     * Default value: {@code false}
+     */
+    @ConfigValue(docIndex = "configuration.html#pom-io")
+    public static final String SUPPRESS_MANIFEST_COMMENT = "suppressManifestComment";
+
     private static final String MODIFIED_BY = "Modified by POM Manipulation Extension for Maven";
 
     private static final Logger logger = LoggerFactory.getLogger(PomIO.class);
@@ -78,18 +91,22 @@ public class PomIO {
 
     private final JDOMModelConverter jdomModelConverter = new JDOMModelConverter();
 
+    private final MavenSessionHandler handler;
+
     private final boolean parsePomTemplates;
 
     private String manifestComment;
 
     @Inject
     public PomIO(MavenSessionHandler handler) {
+        this.handler = handler;
         parsePomTemplates = Boolean.parseBoolean(
                 handler.getUserProperties().getProperty(PARSE_POM_TEMPLATES, "true"));
     }
 
     // Test use only.
     public PomIO() {
+        this.handler = null;
         parsePomTemplates = true;
     }
 
@@ -273,7 +290,10 @@ public class PomIO {
 
             jdomModelConverter.convertModelToJDOM(model, doc);
 
-            if (project.isExecutionRoot()) {
+            boolean suppressManifestComment = handler != null && Boolean.parseBoolean(
+                    handler.getUserProperties().getProperty(SUPPRESS_MANIFEST_COMMENT, "false"));
+
+            if (project.isExecutionRoot() && !suppressManifestComment) {
                 // Previously it was possible to add a comment outside of the root element (which maven3-model-jdom-support handled)
                 // but the release plugin code only takes account of code within the root element and everything else is handled separately.
                 //

--- a/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/PomIOTest.java
+++ b/io/src/test/java/org/jboss/pnc/mavenmanipulator/io/PomIOTest.java
@@ -25,12 +25,17 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.model.Model;
+import org.apache.maven.settings.Settings;
+import org.jboss.pnc.mavenmanipulator.common.exception.ManipulationException;
 import org.jboss.pnc.mavenmanipulator.common.model.Project;
+import org.jboss.pnc.mavenmanipulator.common.session.MavenSessionHandler;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -190,5 +195,74 @@ public class PomIOTest {
         pomIO.rewritePOMs(changed);
         s = FileUtils.readFileToString(targetFile, StandardCharsets.UTF_8);
         assertEquals(1, StringUtils.countMatches(s, "Modified by POM Manipulation Extension"));
+    }
+
+    @Test
+    public void testSuppressManifestComment()
+            throws Exception {
+        URL resource = PomIOTest.class.getResource(filename);
+        assertNotNull(resource);
+        File pom = new File(resource.getFile());
+        assertTrue(pom.exists());
+
+        File targetFile = folder.newFile("target.xml");
+        FileUtils.copyFile(pom, targetFile);
+
+        Properties userProps = new Properties();
+        userProps.setProperty(PomIO.SUPPRESS_MANIFEST_COMMENT, "true");
+
+        MavenSessionHandler mockHandler = new MavenSessionHandler() {
+            @Override
+            public Properties getUserProperties() {
+                return userProps;
+            }
+
+            @Override
+            public List<ArtifactRepository> getRemoteRepositories() {
+                return null;
+            }
+
+            @Override
+            public File getPom() throws ManipulationException {
+                return null;
+            }
+
+            @Override
+            public File getTargetDir() {
+                return null;
+            }
+
+            @Override
+            public ArtifactRepository getLocalRepository() {
+                return null;
+            }
+
+            @Override
+            public List<String> getActiveProfiles() {
+                return null;
+            }
+
+            @Override
+            public Settings getSettings() {
+                return null;
+            }
+
+            @Override
+            public List<String> getExcludedScopes() {
+                return null;
+            }
+        };
+
+        PomIO suppressPomIO = new PomIO(mockHandler);
+
+        Project project = suppressPomIO.parseProject(null, targetFile).get(0);
+        project.setExecutionRoot();
+
+        HashSet<Project> changed = new HashSet<>();
+        changed.add(project);
+        suppressPomIO.rewritePOMs(changed);
+
+        String s = FileUtils.readFileToString(targetFile, StandardCharsets.UTF_8);
+        assertEquals(0, StringUtils.countMatches(s, "Modified by POM Manipulation Extension"));
     }
 }


### PR DESCRIPTION
NCLSUP-1478 Add a suppressManifestComment option that will suppress the printing of the footer manifest comment "Modified by POM Manipulation Extension for Maven".

Example 

```
</project>
<!--
Modified by POM Manipulation Extension for Maven 5.6-SNAPSHOT ( SHA: e8a5fe82095d0ca622ab4efd37afd1b8d9ac95c7 )
-->
```