### PR TITLE
NCLSUP-1482 Write json file if no changes

### DIFF
--- a/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/ManipulationManager.java
+++ b/core/src/main/java/org/jboss/pnc/mavenmanipulator/core/ManipulationManager.java
@@ -93,6 +93,9 @@ public class ManipulationManager {
     @ConfigValue(docIndex = "../index.html#summary-logging")
     public static final String REPORT_JSON_OUTPUT_FILE = "reportJSONOutputFile";
 
+    @ConfigValue(docIndex = "../index.html#summary-logging")
+    public static final String REPORT_JSON_UNCHANGED = "reportJsonUnchanged";
+
     @ConfigValue(docIndex = "../index.html#deprecated-and-unknown-properties")
     public static final String DEPRECATED_PROPERTIES = "enabledDeprecatedProperties";
 
@@ -264,14 +267,7 @@ public class ManipulationManager {
                     File reportFile = new File(reportTxtOutputFile);
                     FileUtils.writeStringToFile(reportFile, report, StandardCharsets.UTF_8);
                 }
-                final String reportJsonOutputFile = session.getUserProperties()
-                        .getProperty(
-                                REPORT_JSON_OUTPUT_FILE,
-                                session.getTargetDir() + File.separator + REPORT_JSON_DEFAULT);
-
-                try (FileWriter writer = new FileWriter(reportJsonOutputFile)) {
-                    writer.write(JSONUtils.jsonToString(jsonReport));
-                }
+                writeJsonReport(session);
 
                 if (Boolean.parseBoolean(session.getUserProperties().getProperty(REWRITE_CHANGED, "true"))) {
                     logger.debug("Maven-Manipulation-Extension: Rewrite changed");
@@ -282,6 +278,19 @@ public class ManipulationManager {
                 logger.error("Unable to create marker or result file", e);
                 throw new ManipulationException("Marker/result file creation failed", e);
             }
+        } else if (Boolean.parseBoolean(
+                session.getUserProperties().getProperty(REPORT_JSON_UNCHANGED, "false"))) {
+            logger.info(
+                    "Maven-Manipulation-Extension: No changes; writing JSON report for unchanged project.");
+            jsonReport.getGav().setPVR(originalExecutionRoot.getResolvedKey());
+            jsonReport.getGav().setOriginalGAV(originalExecutionRoot.getResolvedKey().toString());
+            try {
+                session.getTargetDir().mkdir();
+                writeJsonReport(session);
+            } catch (IOException e) {
+                logger.error("Unable to create result file", e);
+                throw new ManipulationException("Result file creation failed", e);
+            }
         }
 
         // Ensure shutdown of GalleyInfrastructure Executor Service
@@ -290,6 +299,16 @@ public class ManipulationManager {
         }
 
         logger.info("Maven-Manipulation-Extension: Finished.");
+    }
+
+    private void writeJsonReport(final ManipulationSession session) throws IOException {
+        final String reportJsonOutputFile = session.getUserProperties()
+                .getProperty(
+                        REPORT_JSON_OUTPUT_FILE,
+                        session.getTargetDir() + File.separator + REPORT_JSON_DEFAULT);
+        try (FileWriter writer = new FileWriter(reportJsonOutputFile)) {
+            writer.write(JSONUtils.jsonToString(jsonReport));
+        }
     }
 
     @SuppressWarnings({ "unchecked", "deprecation" })

--- a/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/ManipulationManagerTest.java
+++ b/core/src/test/java/org/jboss/pnc/mavenmanipulator/core/ManipulationManagerTest.java
@@ -30,6 +30,8 @@ import javax.inject.Named;
 
 import org.apache.commons.io.FileUtils;
 import org.jboss.pnc.mavenmanipulator.common.exception.ManipulationException;
+import org.jboss.pnc.mavenmanipulator.common.json.PME;
+import org.jboss.pnc.mavenmanipulator.common.util.JSONUtils;
 import org.jboss.pnc.mavenmanipulator.core.fixture.PlexusTestRunner;
 import org.jboss.pnc.mavenmanipulator.core.fixture.TestUtils;
 import org.jboss.pnc.mavenmanipulator.core.impl.Manipulator;
@@ -86,6 +88,75 @@ public class ManipulationManagerTest {
         assertTrue(
                 systemRule.getLog().contains("Disabling strictPropertyValidation as dependencyOverrides are enabled"));
         assertEquals(0, (int) commonState.getStrictDependencyPluginPropertyValidation());
+    }
+
+    @Test
+    public void testReportJsonUnchanged_disabledByDefault()
+            throws IOException, ManipulationException {
+        final File root = folder.newFolder();
+        final File base = TestUtils.resolveFileResource("groovy-project-removal", "");
+        FileUtils.copyDirectory(base, root);
+        final File projectRoot = new File(root, "pom.xml");
+
+        // No versionIncrementalSuffix → nothing changes; flag not set → default false
+        Properties p = new Properties();
+        TestUtils.SMContainer smc = TestUtils.createSessionAndManager(p, projectRoot);
+        smc.getManager().scanAndApply(smc.getSession());
+
+        final File reportFile = new File(root, "target/" + ManipulationManager.REPORT_JSON_DEFAULT);
+        assertFalse("JSON report must NOT be written when reportJsonUnchanged is false", reportFile.exists());
+    }
+
+    @Test
+    public void testReportJsonUnchanged_writesFileWhenEnabled()
+            throws IOException, ManipulationException {
+        final File root = folder.newFolder();
+        final File base = TestUtils.resolveFileResource("groovy-project-removal", "");
+        FileUtils.copyDirectory(base, root);
+        final File projectRoot = new File(root, "pom.xml");
+
+        // No versionIncrementalSuffix → nothing changes; flag enabled
+        Properties p = new Properties();
+        p.setProperty(ManipulationManager.REPORT_JSON_UNCHANGED, "true");
+
+        TestUtils.SMContainer smc = TestUtils.createSessionAndManager(p, projectRoot);
+        smc.getManager().scanAndApply(smc.getSession());
+
+        final File reportFile = new File(root, "target/" + ManipulationManager.REPORT_JSON_DEFAULT);
+        assertTrue("JSON report must be written when reportJsonUnchanged is true", reportFile.exists());
+
+        final PME pme = JSONUtils.fileToJSON(reportFile);
+        assertEquals("com.example", pme.getGav().getGroupId());
+        assertEquals("groovy-project-removal", pme.getGav().getArtifactId());
+        assertEquals("1.0.0", pme.getGav().getVersion());
+        assertEquals("com.example:groovy-project-removal:1.0.0", pme.getGav().getOriginalGAV());
+        assertTrue("modules list must be empty for unchanged project", pme.getModules().isEmpty());
+    }
+
+    @Test
+    public void testReportJsonUnchanged_resolvesVersionProperty()
+            throws IOException, ManipulationException {
+        final File root = folder.newFolder();
+        final File resource = TestUtils.resolveFileResource("", "pom-version-property.xml");
+        final File projectRoot = new File(root, "pom.xml");
+        FileUtils.copyFile(resource, projectRoot);
+
+        // No versionIncrementalSuffix → nothing changes; flag enabled
+        Properties p = new Properties();
+        p.setProperty(ManipulationManager.REPORT_JSON_UNCHANGED, "true");
+
+        TestUtils.SMContainer smc = TestUtils.createSessionAndManager(p, projectRoot);
+        smc.getManager().scanAndApply(smc.getSession());
+
+        final File reportFile = new File(root, "target/" + ManipulationManager.REPORT_JSON_DEFAULT);
+        assertTrue("JSON report must be written when reportJsonUnchanged is true", reportFile.exists());
+
+        final PME pme = JSONUtils.fileToJSON(reportFile);
+        // ${myVersion} must be resolved to its declared value "2.0.0", not left as a literal expression
+        assertEquals("com.example", pme.getGav().getGroupId());
+        assertEquals("version-property-project", pme.getGav().getArtifactId());
+        assertEquals("2.0.0", pme.getGav().getVersion());
+        assertEquals("com.example:version-property-project:2.0.0", pme.getGav().getOriginalGAV());
     }
 
     @Test

--- a/core/src/test/resources/pom-version-property.xml
+++ b/core/src/test/resources/pom-version-property.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2012 Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example</groupId>
+  <artifactId>version-property-project</artifactId>
+  <version>${myVersion}</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <myVersion>2.0.0</myVersion>
+  </properties>
+
+</project>


### PR DESCRIPTION
This will need a doc update. By default there a no user-facing changes. If `reportJsonUnchanged` is true, then the report json file will be written regardless of whether there are changes or not.